### PR TITLE
Improve ux and fix typos in docker run commands

### DIFF
--- a/docs/operate/relayer/run-relayer.mdx
+++ b/docs/operate/relayer/run-relayer.mdx
@@ -164,7 +164,7 @@ For example, if your local validator is writing signatures to `/tmp/hyperlane-va
 ```sh
 docker run \
   -it \
-  -e CONFIG_FILES=/path/to/file/inside/container
+  -e CONFIG_FILES=/path/to/file/inside/container \
   --mount type=bind,source="$(pwd)"/hyperlane-validator-signatures-ethereum,target=/tmp/hyperlane-validator-signatures-ethereum,readonly \
   --mount type=bind,source="$(pwd)"/hyperlane_db,target=/hyperlane_db \
   $DOCKER_IMAGE \

--- a/docs/operate/validators/run-validators.mdx
+++ b/docs/operate/validators/run-validators.mdx
@@ -230,7 +230,7 @@ For example, if your local validator is writing signatures to `/tmp/hyperlane-va
 ```sh
 docker run \
   -it \
-  -e CONFIG_FILES=/path/to/file/inside/container
+  -e CONFIG_FILES=/path/to/file/inside/container \
   --mount type=bind,source="$(pwd)"/hyperlane-validator-signatures-ethereum,target=/tmp/hyperlane-validator-signatures-ethereum,readonly \
   --mount type=bind,source="$(pwd)"/hyperlane_db,target=/hyperlane_db \
   $DOCKER_IMAGE \

--- a/docs/operate/validators/run-validators.mdx
+++ b/docs/operate/validators/run-validators.mdx
@@ -100,7 +100,7 @@ When running a validator locally, your validator will write its signatures to a 
 MY_VALIDATOR_SIGNATURES_DIRECTORY=/tmp/hyperlane-validator-signatures-ethereum
 
 # Create the directory
-mkdir $MY_VALIDATOR_SIGNATURES_DIRECTORY
+mkdir -p $MY_VALIDATOR_SIGNATURES_DIRECTORY
 ```
 
 


### PR DESCRIPTION
- It would be better to create a folder if it doesn't exist (that way there is no error if the folder doesn't exist).
- Missing mandatory slashes in commands