### PR TITLE
docs: fix typo

### DIFF
--- a/docs/partials/deploy-hyperlane/_deploy-warp-route.mdx
+++ b/docs/partials/deploy-hyperlane/_deploy-warp-route.mdx
@@ -22,4 +22,4 @@ Follow the detailed [**Deploy Warp Guide**](/docs/guides/deploy-warp-route) to l
 
 ### Deploy the Warp UI
 
-The Warp UI is a DApp template for interacting with Warp Routes. You can clone the [Warp UI repo](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template) and follow the instructions in CUSTOMIZE.md to configure and a new instance. In short, use the `chains.yaml` and `warp-ui-token-config.json` files from the previous steps to provide the UI with the information it needs. See the [**Deploy Warp UI guide**](/docs/guides/deploy-warp-route-UI) for step-by-step instructions.
+The Warp UI is a DApp template for interacting with Warp Routes. You can clone the [Warp UI repo](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template) and follow the instructions in CUSTOMIZE.md to configure and create a new instance. In short, use the `chains.yaml` and `warp-ui-token-config.json` files from the previous steps to provide the UI with the information it needs. See the [**Deploy Warp UI guide**](/docs/guides/deploy-warp-route-UI) for step-by-step instructions.


### PR DESCRIPTION
Original text: "follow the instructions in CUSTOMIZE.md to configure and a new instance"
Corrected text: "follow the instructions in CUSTOMIZE.md to configure and create a new instance"