### PR TITLE
fix: cargo build command

### DIFF
--- a/docs/guides/deploy-hyperlane-local-agents.mdx
+++ b/docs/guides/deploy-hyperlane-local-agents.mdx
@@ -239,7 +239,7 @@ cargo run --release --bin validator -- \
 You can alternatively build out the agent:
 
 ```sh
-cargo build --release bin validator
+cargo build --release --bin validator
 ```
 
 And run the binary directly:
@@ -387,7 +387,7 @@ The metrics port is overriden to avoid clashing with the validator.
 You can alternatively build out the agent:
 
 ```sh
-cargo build --release bin relayer
+cargo build --release --bin relayer
 ```
 
 And run the binary directly:


### PR DESCRIPTION
## Notes

Fix the `cargo build` command when building `relayer` and `validator` inside `hyperlane-monorepo`