### PR TITLE
add ISM module type formats

### DIFF
--- a/docs/protocol/ISM/modular-security.mdx
+++ b/docs/protocol/ISM/modular-security.mdx
@@ -123,5 +123,3 @@ sequenceDiagram
     Mailbox->>Recipient: handle(origin, sender, body)
 
 ```
-import { testRecipientFactories } from "@hyperlane-xyz/sdk/dist/core/TestRecipientDeployer"
-

--- a/docs/protocol/ISM/modular-security.mdx
+++ b/docs/protocol/ISM/modular-security.mdx
@@ -88,6 +88,12 @@ See the [`Message.sol`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob
 
 The secondary function that ISMs must implement is `moduleType()`. This is used to signal to the [Relayer](../agents/relayer.mdx) what to include in `_metadata`. ISMs **must** return one of the supported module types.
 
+:::tip
+
+For more information on the available module types and their respective metadata, please visit the ISM docs outlined in this section, e.g. [Multisig ISM](./multisig-ISM.mdx).
+
+:::
+
 ## Sequence diagram
 
 The following shows a simplified sequence diagram of an interchain message being verified and delivered on the destination chain.
@@ -117,3 +123,5 @@ sequenceDiagram
     Mailbox->>Recipient: handle(origin, sender, body)
 
 ```
+import { testRecipientFactories } from "@hyperlane-xyz/sdk/dist/core/TestRecipientDeployer"
+

--- a/docs/protocol/ISM/multisig-ISM.mdx
+++ b/docs/protocol/ISM/multisig-ISM.mdx
@@ -1,3 +1,40 @@
 # Multisig ISM
 
 The `MultisigISM` is one of the most commonly used ISM types. These ISMs verify that `m` of `n` [Validators](../agents/validators.mdx) have attested to the validity of a particular interchain message.
+
+## Multisig Module Types
+
+Based on the following module types, the relayer will encode the appropriately formatted metadata:
+
+```solidity
+enum Types {
+    ...
+    MERKLE_ROOT_MULTISIG,
+    MESSAGE_ID_MULTISIG,
+    ...
+}
+```
+
+For the aforementioned module Types, the following metadata formats are satisfied by the relayer for use by the ISMs:
+
+### MessageIdMultisigIsmMetadata
+
+```solidity
+Format of metadata:
+[   0:  32] Origin merkle tree address
+[  32:  64] Signed checkpoint root
+[  64:  68] Signed checkpoint index
+[  68:????] Validator signatures (length := threshold * 65)
+```
+
+### MerkleRootMultisigIsmMetadata
+
+```solidity
+Format of metadata:
+[   0:  32] Origin merkle tree address
+[  32:  36] Index of message ID in merkle tree
+[  36:  68] Signed checkpoint message ID
+[  68:1092] Merkle proof
+[1092:1096] Signed checkpoint index (computed from proof and index)
+[1096:????] Validator signatures (length := threshold * 65)
+```

--- a/docs/protocol/ISM/multisig-ISM.mdx
+++ b/docs/protocol/ISM/multisig-ISM.mdx
@@ -6,35 +6,29 @@ The `MultisigISM` is one of the most commonly used ISM types. These ISMs verify 
 
 Based on the following module types, the relayer will encode the appropriately formatted metadata:
 
-```solidity
-enum Types {
-    ...
-    MERKLE_ROOT_MULTISIG,
-    MESSAGE_ID_MULTISIG,
-    ...
-}
+```solidity file=<rootDir>/node_modules/@hyperlane-xyz/core/contracts/interfaces/IInterchainSecurityModule.sol#L5-L14
 ```
 
-For the aforementioned module Types, the following metadata formats are satisfied by the relayer for use by the ISMs:
+For the aforementioned module types, the following metadata formats are satisfied by the relayer for use by the ISMs:
 
 ### MessageIdMultisigIsmMetadata
 
-```solidity
-Format of metadata:
-[   0:  32] Origin merkle tree address
-[  32:  64] Signed checkpoint root
-[  64:  68] Signed checkpoint index
-[  68:????] Validator signatures (length := threshold * 65)
-```
+#### Type: `Types.MESSAGE_ID_MULTISIG`
+
+#### Format of metadata:
+- `1st slot (len == 32 bytes): Origin merkle tree address`
+- `2nd slot (len == 32 bytes): Signed checkpoint root`
+- `3rd slot (len == 4 bytes): Signed checkpoint index`
+- `4th slot (len == threshold * 65 bytes): Validator signatures`
 
 ### MerkleRootMultisigIsmMetadata
 
-```solidity
-Format of metadata:
-[   0:  32] Origin merkle tree address
-[  32:  36] Index of message ID in merkle tree
-[  36:  68] Signed checkpoint message ID
-[  68:1092] Merkle proof
-[1092:1096] Signed checkpoint index (computed from proof and index)
-[1096:????] Validator signatures (length := threshold * 65)
-```
+#### Type: `Types.MERKLE_ROOT_MULTISIG`
+
+#### Format of metadata:
+- `1st slot (len == 32 bytes) Origin merkle tree address`
+- `2nd slot (len == 4 bytes) Index of message ID in merkle tree`
+- `3rd slot (len == 32 bytes) Signed checkpoint message ID`
+- `4th slot (len == 1024 bytes) Merkle proof`
+- `5th slot (len == 4 bytes) Signed checkpoint index (computed from proof and index)`
+- `6th slot (len == threshold * 65 bytes): Validator signatures`

--- a/docs/protocol/ISM/multisig-ISM.mdx
+++ b/docs/protocol/ISM/multisig-ISM.mdx
@@ -16,19 +16,29 @@ For the aforementioned module types, the following metadata formats are satisfie
 #### Type: `Types.MESSAGE_ID_MULTISIG`
 
 #### Format of metadata:
-- `1st slot (len == 32 bytes): Origin merkle tree address`
-- `2nd slot (len == 32 bytes): Signed checkpoint root`
-- `3rd slot (len == 4 bytes): Signed checkpoint index`
-- `4th slot (len == threshold * 65 bytes): Validator signatures`
+- `1st component (len == 32 bytes): Origin merkle tree address`
+- `2nd component (len == 32 bytes): Signed checkpoint root`
+- `3rd component (len == 4 bytes): Signed checkpoint index`
+- `4th component (len == threshold * 65 bytes): Validator signatures`
+
+{/* ```mermaid
+block-beta
+    columns 4
+    a["[32 bytes] Origin merkle tree address"]:2 b["[32 bytes] Signed checkpoint root"]:2
+    c["[4 bytes] Signed checkpoint index"]:1
+    block:group:3
+        d["[65 bytes] Validator signatures"] e["[65 bytes] Validator signatures"] f["[65 bytes] Validator signatures"]
+    end
+``` */}
 
 ### MerkleRootMultisigIsmMetadata
 
 #### Type: `Types.MERKLE_ROOT_MULTISIG`
 
 #### Format of metadata:
-- `1st slot (len == 32 bytes) Origin merkle tree address`
-- `2nd slot (len == 4 bytes) Index of message ID in merkle tree`
-- `3rd slot (len == 32 bytes) Signed checkpoint message ID`
-- `4th slot (len == 1024 bytes) Merkle proof`
-- `5th slot (len == 4 bytes) Signed checkpoint index (computed from proof and index)`
-- `6th slot (len == threshold * 65 bytes): Validator signatures`
+- `1st component (len == 32 bytes) Origin merkle tree address`
+- `2nd component (len == 4 bytes) Index of message ID in merkle tree`
+- `3rd component (len == 32 bytes) Signed checkpoint message ID`
+- `4th component (len == 1024 bytes) Merkle proof`
+- `5th component (len == 4 bytes) Signed checkpoint index (computed from proof and index)`
+- `6th component (len == threshold * 65 bytes): Validator signatures`

--- a/docs/reference/ISM/specify-your-ISM.mdx
+++ b/docs/reference/ISM/specify-your-ISM.mdx
@@ -40,14 +40,22 @@ The Mailbox will call `verify` before delivering a message to its recipient. If 
 ```solidity file=<rootDir>/node_modules/@hyperlane-xyz/core/contracts/interfaces/IInterchainSecurityModule.sol#L21
 ```
 
-This is used to signal to the Relayer how to encode `_metadata`. ISMs **must** return one of the supported module types.
+This is used to signal to the Relayer how to encode `_metadata`. ISMs **must** return one of the supported module types:
 
 ```solidity file=<rootDir>/node_modules/@hyperlane-xyz/core/contracts/interfaces/IInterchainSecurityModule.sol#L5-L14
 ```
 
+:::note
+
+To accomplish this, all ISM contracts are initialized with a `moduleType` constant state variable.
+This public state is branched on by the Relayer in order to determine the recipient's ISM and the respective required metadata for that ISM.
+For more information on module Types and their metadata formats, see [Protocol](/docs/protocol/ISM/modular-security.mdx#module-type).
+
+:::
+
 ## Specifying an ISM
 
-To specify the ISM they would like to use, developers implement the `ISpecifiesInterchainSecurityModule` interface in any contract that receives interchain messages via `handle()`. 
+To specify the ISM they would like to use, developers implement the `ISpecifiesInterchainSecurityModule` interface in any contract that receives interchain messages via `handle()`.
 
 ```solidity
 interface ISpecifiesInterchainSecurityModule {

--- a/docs/reference/ISM/specify-your-ISM.mdx
+++ b/docs/reference/ISM/specify-your-ISM.mdx
@@ -48,7 +48,7 @@ This is used to signal to the Relayer how to encode `_metadata`. ISMs **must** r
 :::note
 
 To accomplish this, all ISM contracts implement the ISM interface, which requires `moduleType` to be defined.
-This public state is branched on by the Relayer in order to determine the required metadata for that ISM.
+This type is branched on by the Relayer in order to determine the required metadata for that ISM.
 For more information on module types and their metadata formats, see [Protocol](/docs/protocol/ISM/modular-security.mdx#module-type).
 
 :::

--- a/docs/reference/ISM/specify-your-ISM.mdx
+++ b/docs/reference/ISM/specify-your-ISM.mdx
@@ -47,9 +47,9 @@ This is used to signal to the Relayer how to encode `_metadata`. ISMs **must** r
 
 :::note
 
-To accomplish this, all ISM contracts are initialized with a `moduleType` constant state variable.
-This public state is branched on by the Relayer in order to determine the recipient's ISM and the respective required metadata for that ISM.
-For more information on module Types and their metadata formats, see [Protocol](/docs/protocol/ISM/modular-security.mdx#module-type).
+To accomplish this, all ISM contracts implement the ISM interface, which requires `moduleType` to be defined.
+This public state is branched on by the Relayer in order to determine the required metadata for that ISM.
+For more information on module types and their metadata formats, see [Protocol](/docs/protocol/ISM/modular-security.mdx#module-type).
 
 :::
 


### PR DESCRIPTION
## Description
- Adds information on module type metadata formats, related to the ISMs for which they are used

## Related Issues

- https://github.com/hyperlane-xyz/issues/issues/1194