### PR TITLE
Fix Syntax Error in MessageQuickstart.tsx

### DIFF
--- a/src/components/MessageQuickstart.tsx
+++ b/src/components/MessageQuickstart.tsx
@@ -34,7 +34,7 @@ export default function MessageQuickstart() {
             Send the message:
             <CodeBlock language="shell">
               hyperlane send message --origin {originChain} --destination{" "}
-              {destinationChain} --body "{body}""
+              {destinationChain} --body "{body}"
             </CodeBlock>
           </TabItem>
           <TabItem value="cast" label="Cast">


### PR DESCRIPTION
This PR addresses a syntax error in the example command provided in the MessageQuickstart.tsx file for sending messages using the Hyperlane CLI. 
The original example included an unnecessary quotation mark at the end of the --body parameter, which could lead to execution errors.