### PR TITLE
Improve Documentation Accessibility

### DIFF
--- a/docs/reference/messaging/messaging-interface.mdx
+++ b/docs/reference/messaging/messaging-interface.mdx
@@ -16,6 +16,8 @@ To [**receive**](./receive.mdx) interchain messages, implement the `handle` func
 <details>
 <summary>`IMailbox` Interface</summary>
 
+See the [`IMailbox Interface`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/interfaces/IMailbox.sol) for details.
+
 <Tabs groupId="lang">
 <TabItem value="sol" label="Solidity">
 

--- a/docs/reference/messaging/receive.mdx
+++ b/docs/reference/messaging/receive.mdx
@@ -59,7 +59,7 @@ The following utility is provided in the [`MailboxClient` library](../libraries/
 <Tabs groupId="lang">
 <TabItem value="sol" label="Solidity">
 
-```solidity file=<rootDir>/node_modules/@hyperlane-xyz/core/contracts/client/MailboxClient.sol#L45-L51
+```solidity file=<rootDir>/node_modules/@hyperlane-xyz/core/contracts/client/MailboxClient.sol#L44-L53
 ```
 
 </TabItem>

--- a/docs/reference/messaging/receive.mdx
+++ b/docs/reference/messaging/receive.mdx
@@ -59,7 +59,7 @@ The following utility is provided in the [`MailboxClient` library](../libraries/
 <Tabs groupId="lang">
 <TabItem value="sol" label="Solidity">
 
-```solidity file=<rootDir>/node_modules/@hyperlane-xyz/core/contracts/client/MailboxClient.sol#L44-L53
+```solidity file=<rootDir>/node_modules/@hyperlane-xyz/core/contracts/client/MailboxClient.sol#L47-L53
 ```
 
 </TabItem>

--- a/docs/reference/messaging/send.mdx
+++ b/docs/reference/messaging/send.mdx
@@ -12,7 +12,7 @@ Contracts can send interchain messages by calling the `dispatch` function on the
 <SimpleMessagingDiagram/>
 
 <details>
-<summary>[`IMailbox`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/interfaces/IMailbox.sol) Interface</summary>
+<summary>`IMailbox` Interface</summary>
 
 <Tabs groupId="lang">
 <TabItem value="sol" label="Solidity">
@@ -23,6 +23,8 @@ Contracts can send interchain messages by calling the `dispatch` function on the
 </TabItem>
 </Tabs>
 </details>
+
+See the [`IMailbox Interface`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/interfaces/IMailbox.sol) for details.
 
 ## Dispatch
 

--- a/docs/reference/messaging/send.mdx
+++ b/docs/reference/messaging/send.mdx
@@ -14,6 +14,8 @@ Contracts can send interchain messages by calling the `dispatch` function on the
 <details>
 <summary>`IMailbox` Interface</summary>
 
+See the [`IMailbox Interface`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/interfaces/IMailbox.sol) for details.
+
 <Tabs groupId="lang">
 <TabItem value="sol" label="Solidity">
 
@@ -23,8 +25,6 @@ Contracts can send interchain messages by calling the `dispatch` function on the
 </TabItem>
 </Tabs>
 </details>
-
-See the [`IMailbox Interface`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/interfaces/IMailbox.sol) for details.
 
 ## Dispatch
 

--- a/docs/reference/messaging/send.mdx
+++ b/docs/reference/messaging/send.mdx
@@ -12,7 +12,7 @@ Contracts can send interchain messages by calling the `dispatch` function on the
 <SimpleMessagingDiagram/>
 
 <details>
-<summary>`IMailbox` Interface</summary>
+<summary>[`IMailbox`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/solidity/contracts/interfaces/IMailbox.sol) Interface</summary>
 
 <Tabs groupId="lang">
 <TabItem value="sol" label="Solidity">


### PR DESCRIPTION
In this PR, I've made some updates to the documentation to improve its accessibility. 

In this PR, I've updated the `send.mdx` documentation. I've added a quick access link to the `IMailbox` interface source code, improving the reading experience. I've also corrected the `onlyMailbox` modifier example. These changes enhance clarity and accessibility.