### PR TITLE
docs: Rectify typographical inaccuracies

### DIFF
--- a/docs/guides/avs-operator-guide.mdx
+++ b/docs/guides/avs-operator-guide.mdx
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Hyperlane validators are light offchain agents responsible for security - they observe messages on an origin chain's [Mailbox](../protocol/mailbox.mdx) and if needed sign a merkle root that attests to the current state of the mailbox.
+Hyperlane validators are light offchain agents responsible for security - they observe messages on an origin chain's [Mailbox](../protocol/mailbox.mdx) and if needed sign a merkle root that attests the current state of the mailbox.
 
 This signature is stored and made publicly available (e.g. in a S3 bucket), which is then used by the offchain Relayer and Interchain Security Modules onchain. Validators are _not_ networked together and do not need to reach consensus.
 

--- a/docs/guides/avs-operator-guide.mdx
+++ b/docs/guides/avs-operator-guide.mdx
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Hyperlane validators are light offchain agents responsible for security - they observe messages on an origin chain's [Mailbox](../protocol/mailbox.mdx) and if needed sign a merkle root that attests the current state of the mailbox.
+Hyperlane validators are light offchain agents responsible for security - they observe messages on an origin chain's [Mailbox](../protocol/mailbox.mdx) and if needed sign a merkle root that attests to the current state of the mailbox.
 
 This signature is stored and made publicly available (e.g. in a S3 bucket), which is then used by the offchain Relayer and Interchain Security Modules onchain. Validators are _not_ networked together and do not need to reach consensus.
 

--- a/docs/guides/create-custom-hook-and-ism.mdx
+++ b/docs/guides/create-custom-hook-and-ism.mdx
@@ -7,7 +7,7 @@ import { MultiLanguageExample } from "@site/src/components/InteractiveExample";
 
 Hooks and ISMs have a complementary relationship: you can customize your behavior from origin and they use a pairwise ISM contract on the destination to verify your custom hook behavior.
 
-You can implement and utilize your own hook and ISM pattern as per your requirements. You can use an external bridge provide like Wormhole or Chainlink's CCIP by implementing the `IPostDispatchHook` interface on the source chain and `IInterchainSecurityModule` on the destination chain.
+You can implement and utilize your own hook and ISM pattern as per your requirements. You can use an external bridge provider like Wormhole or Chainlink's CCIP by implementing the `IPostDispatchHook` interface on the source chain and `IInterchainSecurityModule` on the destination chain.
 
 <details>
 <summary>`IPostDispatchHook` Interface</summary>

--- a/docs/guides/developer-tips/unit-testing.mdx
+++ b/docs/guides/developer-tips/unit-testing.mdx
@@ -14,7 +14,7 @@ contract SimpleMessagingTest is Test {
     uint32 origin = 1;
     uint32 destination = 2;
 
-    // both mailboxes will on the same chain but different addresses
+    // both mailboxes will be on the same chain but different addresses
     MockMailbox originMailbox;
     MockMailbox destinationMailbox;
 

--- a/docs/guides/ecosystems/solana.mdx
+++ b/docs/guides/ecosystems/solana.mdx
@@ -4,4 +4,4 @@ Hyperlane supports Solana Virtual Machine (SVM), and is currently live supportin
 
 You can find the [Sealevel contract implementation here](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/rust/sealevel/programs/mailbox/src/processor.rs).
 
-Our public tooling & docs are currently EVM-only, however, though we have internal tooling that we are working to open source and develop by end of the year. If you're excited about bringing Hyperlane to Solana reach out on [our Discord](https://discord.gg/hyperlane)!
+Our public tooling & docs are currently EVM-only, however, though we have internal tooling that we are working to open source and develop by the end of the year. If you're excited about bringing Hyperlane to Solana reach out on [our Discord](https://discord.gg/hyperlane)!

--- a/docs/guides/explorer/explorer-debugging.mdx
+++ b/docs/guides/explorer/explorer-debugging.mdx
@@ -37,7 +37,7 @@ EVM addresses (`address`) must be left-padded with zeroes to be compliant. Refer
 
 ### Unprocessable
 
-If gas estimation of the message recipient's `IMessageRecipient.handle()` function fails, [relayers](../../protocol/agents/relayer.mdx) will not be able to deliver the message. Relayers will continue to estimate gas for message delivery, as state changes may allow for successful delivery of a previously undeliverable message.
+If the gas estimation of the message recipient's `IMessageRecipient.handle()` function fails, [relayers](../../protocol/agents/relayer.mdx) will not be able to deliver the message. Relayers will continue to estimate gas for message delivery, as state changes may allow for successful delivery of a previously undeliverable message.
 
 <figure>
 ![](/img/explorer-debugging/call-revert-exception.png)

--- a/docs/guides/explorer/graphql-api.mdx
+++ b/docs/guides/explorer/graphql-api.mdx
@@ -3,7 +3,7 @@
 The Hyperlane agents collect useful information about activity on the system, including all messages. That data can be queried via APIs. These APIs are currently available free of charge and without any required authentication. Connect your preferred GraphQL client or library to [https://api.hyperlane.xyz/v1/graphql](https://api.hyperlane.xyz/v1/graphql) to query data!
 
 :::info
-Note, the REST API is recommended over the GraphQL API because it exposes a simpler schema for message data.&#x20;
+Note, that the REST API is recommended over the GraphQL API because it exposes a simpler schema for message data.&#x20;
 :::
 
 ### Example Query

--- a/docs/guides/explorer/rest-api.mdx
+++ b/docs/guides/explorer/rest-api.mdx
@@ -109,7 +109,7 @@ Action: `search-messages`, Parameter (1 required):
 
 ### APIs for Permissionless Interoperability chains
 
-Hyperlane can be [permissionlessly deployed](/docs/deploy-hyperlane.mdx) to any chain, but messages on PI chains cannot be identified by the default Hyperlane agents. To view details about messages from PI chains, query the `search-pi-messages` action. The search requires a chain config in the request body. Note, this same functionality is also available in the [explorer UI](/docs/guides/explorer/configuring-pi-chains.mdx).
+Hyperlane can be [permissionlessly deployed](/docs/deploy-hyperlane.mdx) to any chain, but messages on PI chains cannot be identified by the default Hyperlane agents. To view details about messages from PI chains, query the `search-pi-messages` action. The search requires a chain config in the request body. Note, that this same functionality is also available in the [explorer UI](/docs/guides/explorer/configuring-pi-chains.mdx).
 
 ```javascript
 const chainConfig = {


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.