### PR TITLE
Update step 6 of hyperlane deploy

### DIFF
--- a/docs/deploy-hyperlane.mdx
+++ b/docs/deploy-hyperlane.mdx
@@ -329,6 +329,6 @@ git pull canonical main --rebase
 **Thank you for contributing to the future of permissionless interop 🫡**
 :::
 
-## 6) (Optional) Deploy a Warp Route
+## 6) Deploy a Warp UI (Optional) 
 
-To connect tokens using your new Hyperlane deployment, see the [Warp Route deployment guide](/docs/guides/deploy-warp-route.mdx).
+Use the Hyperlane Warp UI app template for interacting with Warp Routes. Continue on to the [Warp UI docs](/docs/guides/deploy-warp-route-UI.mdx) for details on how to set it up.


### PR DESCRIPTION
As noted by a user, the last step of hyperlane deploy is to deploy a warp route, again. This updates it to the expected instructions of deploying a UI