### PR TITLE
chore(faq): fix outdated careers page link

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -85,7 +85,7 @@ A modular approach to security ensures that Hyperlane will continue to stay up t
 <details>
   <summary>**I'm interested in working on Hyperlane, where can I see job openings?**</summary>
   <div>
-    <div>Check out our open roles [here](https://www.hyperlane.xyz/crew).</div>
+    <div>Check out our open roles [here](https://jobs.lever.co/Hyperlane).</div>
   </div>
 </details>
 <details>


### PR DESCRIPTION
The link to the documentation in the FAQ was outdated. This PR updates it to point to the correct documentation URL (https://jobs.lever.co/Hyperlane). This ensures users have access to the relevant information.