### PR TITLE
feat: add post-dispatch hooks replay warning

### DIFF
--- a/docs/reference/hooks/overview.mdx
+++ b/docs/reference/hooks/overview.mdx
@@ -51,6 +51,10 @@ In addition to the `message` dispatched via the Mailbox, the `postDispatch` func
 
 If the `postDispatch` function receives insufficient payment, it may revert.
 
+:::info
+Post-Dispatch Hooks may be replayable. Developers creating custom hooks should implement safe checks to prevent this behavior. [Here](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/b69bc23239ecfc8f8a6277bb0f9bc248cffea234/solidity/contracts/hooks/warp-route/RateLimitedHook.sol#L16) is an example implementation.
+:::
+
 ### Quote Dispatch (Fees)
 
 Fees are often charged in `postDispatch` to cover costs such as destination chain transaction submission and security provisioning. To receive a quote for a corresponding `postDispatch` call, you can query the `quoteDispatch` function.


### PR DESCRIPTION
Add documentation explaining the replayability nature of post-dispatch hooks, and a warning to developers integrating them to be aware of this behavior.

I included it in an INFO box (at the bottom) and it looks like the following image.

The reference implementation I linked is [this](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/b69bc23239ecfc8f8a6277bb0f9bc248cffea234/solidity/contracts/hooks/warp-route/RateLimitedHook.sol#L16).

<img width="851" alt="Screenshot 2024-07-24 at 12 42 15" src="https://github.com/user-attachments/assets/72ff2897-4fbc-4ea8-bdb0-bce8490dc43b">
