### PR TITLE
updating filechain information

### DIFF
--- a/docs/guides/token-faucets.mdx
+++ b/docs/guides/token-faucets.mdx
@@ -22,5 +22,5 @@
 | Fuji            | [Avalanche Faucet​​](https://faucet.avax.network/)                              | 2 AVAX                       |
 | BSC Testnet     | [​​BNB Smart Chain Faucet](https://testnet.bnbchain.org/faucet-smart)           | 0.5 BNB                      |
 | Moonbase Alpha  | [​​Moonbase Alpha Faucet](https://apps.moonbeam.network/moonbase-alpha/faucet/) | 1 DEV                        |
-| Hyperspace      | [Filecoin Faucet](https://hyperspace.yoga/#faucet)                            | 5 tFIL                       |
+| Calibration     | [Filecoin Faucet](https://faucet.calibnet.chainsafe-fil.io/)                  | 5 tFIL                       |
 | Sepolia         | [Sepolia Faucet](https://sepoliafaucet.com/)                                  | 0.5 ETH                      |


### PR DESCRIPTION
filechain Hyperspace Testnet is no longer active. replaced with the current Calibration Testnet.