### PR TITLE
Choose merkle tree hook as default and required hook 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ yarn-error.log*
 !.yarn/versions
 
 .vercel
+
+.idea

--- a/docs/partials/deploy-hyperlane/_deploy-contracts.mdx
+++ b/docs/partials/deploy-hyperlane/_deploy-contracts.mdx
@@ -36,6 +36,8 @@ hyperlane core init --advanced
 
 When asked about the ISM type, choose `messageIdMultisigIsm`. In the context of this guide, we will be using a 1/1 multisig, so choose a threshold of `1` and enter the address of your key.
 
+When asked about the default hook type and required hook type, choose `merkleTreeHook`.
+
 ### Dry Run a Core Deployment
 
 :::note


### PR DESCRIPTION
When I went through the guide on (deploying Hyperlane with local agents)[https://docs.hyperlane.xyz/docs/guides/deploy-hyperlane-local-agents], I found that it is not clear what hook to use as default and required ones.

This PR adds a sentence which advises the reader to choose merkle tree hook.

(If there is a better choice of the hook for the purpose of the guide, I can put it into instead of merkle tree hook.)

Additional change:
* Add .idea into .gitignore