### PR TITLE
Update validator-signatures-aws.mdx (corrected a typo)

### DIFF
--- a/docs/operate/validators/validator-signatures-aws.mdx
+++ b/docs/operate/validators/validator-signatures-aws.mdx
@@ -81,6 +81,6 @@ Your Validator IAM user will need write permissions, and it should be publicly r
 
 :::tip
 
-Advanced users may consider using the [S3 terraform module](../deploy-with-terraform.mdx#iam--kms) instead to create the S3 bucket with the correct permissions.
+Advanced users may consider using the [S3 Terraform module](../deploy-with-terraform.mdx#iam--kms) instead to create the S3 bucket with the correct permissions.
 
 :::


### PR DESCRIPTION
Corrected a typo in the word "Terraform" which was missing a capital "T" (to match the correct product name).