### PR TITLE
Update run-validators.mdx (corrected a small typo)

### DIFF
--- a/docs/operate/validators/run-validators.mdx
+++ b/docs/operate/validators/run-validators.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 Hyperlane validators are light offchain agents responsible for security - they observe messages on an origin chain's [Mailbox](../../protocol/mailbox.mdx) and if needed sign a merkle root that attests the current state of the mailbox.
 
-This signature is stored and made publicly available (e.g. in a S3 bucket), which is then used by the offchain Relayer and Interchain Security Modules onchain. Validators are _not_ networked together and do not need to reach consensus; they also do not regularly submit onchain transactions.
+This signature is stored and made publicly available (e.g. in an S3 bucket), which is then used by the offchain Relayer and Interchain Security Modules onchain. Validators are _not_ networked together and do not need to reach consensus; they also do not regularly submit onchain transactions.
 
 As you follow this guide, you can run a Hyperlane validator on any of the existing [chains](https://github.com/hyperlane-xyz/hyperlane-registry/tree/main/chains) the protocol is live on. Hyperlane Validators are run on a per-origin-chain basis, and these instructions are written for a single chain.
 


### PR DESCRIPTION
Modified the article from "a" to "an" in the sentence: "(e.g. in an S3 bucket)".