### PR TITLE
Add reference to Warp UI template readme

### DIFF
--- a/docs/guides/deploy-warp-route-UI.mdx
+++ b/docs/guides/deploy-warp-route-UI.mdx
@@ -6,6 +6,8 @@ After you've successfully [deployed a Warp Route](/docs/guides/deploy-warp-route
 
 ## Configure & Customize the UI
 
+Follow the [configuration instructions](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/blob/main/README.md) for details on how to configure the Warp UI Web application and run it locally.
+
 Follow the [customization instructions](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/blob/main/CUSTOMIZE.md) for details on how to configure the UI's tokens and change the default branding assets/theme.
 
 ## Registry


### PR DESCRIPTION
Add reference to Warp UI template readme so that developers know how to run Warp UI locally before they deploy it to Vercel or AWS Amplify. The readme contains instructions related WalletConnect Cloud `projectId`.