### PR TITLE
fix: Less jarring code highlighting

### DIFF
--- a/docs/partials/warp-routes/commands/_warp-apply-symbol-config-default-strategy.mdx
+++ b/docs/partials/warp-routes/commands/_warp-apply-symbol-config-default-strategy.mdx
@@ -1,5 +1,5 @@
 ```bash
-hyperlane warp apply 
+hyperlane warp apply \
     --symbol <tokenSymbol> \
     --config $(pwd)/configs/warp-route-deployment.yaml \
     --strategy gnosis-chain-strategy.yaml

--- a/docs/partials/warp-routes/commands/_warp-apply-symbol-config-default.mdx
+++ b/docs/partials/warp-routes/commands/_warp-apply-symbol-config-default.mdx
@@ -1,5 +1,5 @@
 ```bash
-hyperlane warp apply 
+hyperlane warp apply \
     --symbol <tokenSymbol> \
     --config $(pwd)/configs/warp-route-deployment.yaml
 ```

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -13,6 +13,7 @@
   --ifm-color-primary-light: #276cd3;
   --ifm-color-primary-lighter: #2c72d9;
   --ifm-color-primary-lightest: #4985de;
+  --docusaurus-highlighted-code-line-bg: #CDDCF4;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -24,5 +25,5 @@
   --ifm-color-primary-light: #82A8E4;
   --ifm-color-primary-lighter: #A7C2EC;
   --ifm-color-primary-lightest: #CDDCF4;
+  --docusaurus-highlighted-code-line-bg: #2058ad;
 }
-


### PR DESCRIPTION
- Fix code highlighting to be less jarring. 
<img width="1702" alt="Screenshot 2024-09-17 at 4 50 59 PM" src="https://github.com/user-attachments/assets/232f5fd2-6d78-4c0e-b842-6737bbd24352">


## Drive by
- Add linebreak (\) for command