### PR TITLE
feat: describe `hyperlane_request_count` for monitoring RPC failures in agents

### DIFF
--- a/docs/operate/relayer/monitoring-alerting.mdx
+++ b/docs/operate/relayer/monitoring-alerting.mdx
@@ -25,6 +25,7 @@ The dashboard template includes the following metrics.
 Other relevant metrics include:
 | Metric                                                                         | Description                                                                                                                                                                                                                                                                                                                         |
 |--------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `hyperlane_request_count`                                                      | Records the number of successful or failed RPCs using the following labels: `chain`, `status` (failure or success), `provider_node` (the responsible base RPC URL), and RPC `method`. Present for all agents, but only supported on EVM chains at the moment.                  
 | `hyperlane_wallet_balance{agent="relayer"}`                                    | The relayer's balance on every chain, expressed in the lowest denomination unit                                                                                                                                                                                                                                                     |
 | `hyperlane_critical_error`                                                     | Boolean marker for critical errors on a chain, signalling loss of liveness.                                                                                                                                                                                                                                                     |
 | `hyperlane_block_height`                                                       | The block height of the RPC node the agent is connected to. If this metric is not increasing, the RPC may be unhealthy and need changing.                                                                                                                                                                                           |
@@ -34,9 +35,14 @@ Other relevant metrics include:
 
 ## Alerts
 The metrics above can be combined to create alerts that minimize false positives. Some example critical alerts:
+
+### For all agents:
 - `hyperlane_critical_error` is `1` for a chain, meaning the relayer has lost liveness there. While operations on other chains are not affected by this, this is a high severity alert - usually to do with unreliable RPCs for the affected chain.
-- the prepare queue length has been increasing, and the confirm queue length was zero, and error/warning count diffs have been increasing, over the last 30 minutes. This could mean that the relayer has run out of balance and cannot pay for gas, or that the destination chain RPC url is not working correctly, or just that all new messages are unprocessable
-- `hyperlane_wallet_balance` has dropped below a certain threshold. For example, the current balance divided by the difference in the last 24h is less than 2, meaning balance must be topped up within two days
 - `hyperlane_block_height` has not increased in the last 30 minutes
+- The rate of `hyperlane_request_count{status="failure"}` in the last 10 minutes is > 60% of the rate of `hyperlane_request_count{status=~"success|failure"}`. Most agent issues are due to bad RPCs, and this is likely to catch these issues.
+
+### For relayers:
+- Using `hyperlane_submitter_queue_length{queue_name="prepare_queue"}`, the prepare queue length has been increasing, and the confirm queue length was zero, and error/warning count diffs have been increasing, over the last 30 minutes. This could mean that the relayer has run out of balance and cannot pay for gas, or that the destination chain RPC url is not working correctly, or just that all new messages are unprocessable
+- `hyperlane_wallet_balance` has dropped below a certain threshold. For example, the current balance divided by the difference in the last 24h is less than 2, meaning balance must be topped up within two days
 
 If you get alerted, always check the logs for what the problem could be.


### PR DESCRIPTION
- Documents `hyperlane_request_count` for monitoring RPC failures in agents