### PR TITLE
fix: update docs files with errors 

### DIFF
--- a/docs/guides/explorer/configuring-pi-chains.mdx
+++ b/docs/guides/explorer/configuring-pi-chains.mdx
@@ -8,9 +8,9 @@ Hyperlane can be [deployed](/docs/deploy-hyperlane.mdx) to any chain by anyone, 
 
 ![](/img/explorer-debugging/explorer-add-metadata.png)
 
-2. On the form that appears, enter the chain’s metadata using JSON or YAML confirming to the [ChainMetadata schema](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/sdk/src/metadata/chainMetadataTypes.ts).
+2. On the form that appears, enter the chain’s metadata using JSON or YAML conforming to the [ChainMetadata schema](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/sdk/src/metadata/chainMetadataTypes.ts).
 
-3. If a valid Etherscan-based block explorer config is provided, the Hyperlane Explorer will utilize it to find the desired messages. If not, it will use the RPC URL. Note, Explorers with api keys (even just free-tier keys), perform faster and more reliably.
+3. If a valid Etherscan-based block explorer config is provided, the Hyperlane Explorer will utilize it to find the desired messages. If not, it will use the RPC URL. Note, Explorers with API keys (even just free-tier keys), perform faster and more reliably.
 
 ### Chain Metadata Examples
 

--- a/docs/guides/explorer/explorer-debugging.mdx
+++ b/docs/guides/explorer/explorer-debugging.mdx
@@ -53,4 +53,4 @@ You can [manually pay for interchain gas](../../reference/hooks/interchain-gas.m
 
 ## Using Etherscan
 
-You can also look at the [Etherscan](https://etherscan.io/) page of the recipient on the destination chain however be aware that the processing transaction won't show up on list of transactions as you would typically imagine. The reason for that is that relayers actually call the Mailbox contracts which in turn call the `handle` function on the recipient. Thus, you will find evidence of processing on the under the `Internal Txns` tab instead
+You can also look at the [Etherscan](https://etherscan.io/) page of the recipient on the destination chain however be aware that the processing transaction won't show up on list of transactions as you would typically imagine. The reason for that is that relayers actually call the Mailbox contracts which in turn call the `handle` function on the recipient. Thus, you will find evidence of processing under the `Internal Txns` tab instead

--- a/docs/guides/explorer/explorer.mdx
+++ b/docs/guides/explorer/explorer.mdx
@@ -24,7 +24,7 @@ To search, enter your query into the top search bar. You can use the Origin Chai
 
 Note, by default the explorer will only find message on [core Hyperlane chains](/docs/reference/domains.mdx).
 
-To view messages send to and/or from other chains, see [configuring PI Chains](./configuring-pi-chains.mdx).
+To view messages sent to and/or from other chains, see [Configuring PI Chains](./configuring-pi-chains.mdx).
 
 :::
 


### PR DESCRIPTION
## **Description:**

While reviewing the docs, found and corrected grammar, spelling errors and typos around [configuring-pi-chains.mdx](https://github.com/hyperlane-xyz/v3-docs/blob/main/docs/guides/explorer/configuring-pi-chains.mdx); [explorer-debugging.mdx](https://github.com/hyperlane-xyz/v3-docs/blob/main/docs/guides/explorer/explorer-debugging.mdx); [explorer.mdx](https://github.com/hyperlane-xyz/v3-docs/blob/main/docs/guides/explorer/explorer.mdx) files