### PR TITLE
Fix typos in message-debugging.mdx and _deploy-contracts.mdx

### DIFF
--- a/docs/guides/message-debugging.mdx
+++ b/docs/guides/message-debugging.mdx
@@ -14,7 +14,7 @@ import CosmosMessageDelivered from "@site/src/components/CosmosMessageDelivered"
     <TabItem value="evm" label="EVM Origin">
     The easiest way is to use the [Hyperlane Explorer](https://explorer.hyperlane.xyz), if your chain is supported. If your chain isn't supported, the message ID can be found by looking at the originating transaction.
 
-    When viewing the origin transaction on the origin chain's block explorer, navigate the the **Logs** tab.
+    When viewing the origin transaction on the origin chain's block explorer, navigate to the **Logs** tab.
 
     The **`DispatchId`** log contains the message ID as the topic number 1 (the second topic).
 
@@ -27,7 +27,7 @@ import CosmosMessageDelivered from "@site/src/components/CosmosMessageDelivered"
 
     </TabItem>
     <TabItem value="cosmos" label="Cosmos Origin">
-    When viewing the origin transaction on the origin chain's block explorer, navigate the the **Event Logs** tab.
+    When viewing the origin transaction on the origin chain's block explorer, navigate to the **Event Logs** tab.
 
     The **Wasm Mailbox Dispatch Id** log contains the message ID.
 
@@ -75,7 +75,7 @@ import CosmosMessageDelivered from "@site/src/components/CosmosMessageDelivered"
 
     <Tabs groupId="verifying-recipient">
     <TabItem value="evm" label="EVM Origin">
-    When viewing the origin transaction on the origin chain's block explorer, navigate the the **Logs** tab.
+    When viewing the origin transaction on the origin chain's block explorer, navigate to the **Logs** tab.
 
     The **`SentTransferRemote`** log contains the recipient as the topic number 1 (the second topic).
 
@@ -95,7 +95,7 @@ import CosmosMessageDelivered from "@site/src/components/CosmosMessageDelivered"
     </TabItem>
     <TabItem value="cosmos" label="Cosmos Origin">
 
-    When viewing the origin transaction on the origin chain's block explorer, navigate the the **Event Logs** tab.
+    When viewing the origin transaction on the origin chain's block explorer, navigate to the **Event Logs** tab.
 
     The log including **Transfer Remote** contains the message ID, for example: `Wasm Hpl Warp Native Transfer Remote`.
 

--- a/docs/partials/deploy-hyperlane/_deploy-contracts.mdx
+++ b/docs/partials/deploy-hyperlane/_deploy-contracts.mdx
@@ -80,7 +80,7 @@ We are now ready to generate an agent config using our deployed contracts that w
 hyperlane registry agent-config --chains chain1
 ```
 
-Set the `CONFIG_FILES` enviroment variable to the path of the agent config generated.
+Set the `CONFIG_FILES` environment variable to the path of the agent config generated.
 ```bash
 export CONFIG_FILES=/full/path/to/configs/agent-config.json
 ```


### PR DESCRIPTION
This pull request addresses typographical errors in the following files:

1. **`docs/guides/message-debugging.mdx`**:
   - Corrected "navigate the the" to "navigate to the".

2. **`docs/partials/deploy-hyperlane/_deploy-contracts.mdx`**:
   - Corrected "enviroment" to "environment".