### PR TITLE
Grammar Fix

### DIFF
--- a/docs/reference/glossary.mdx
+++ b/docs/reference/glossary.mdx
@@ -80,11 +80,11 @@ The [Multisig ISM](../protocol/ISM/multisig-ISM.mdx) is a type of [Interchain Se
 
 ## Permissionless Interoperability
 
-Hyperlane can be deployed by anyone to any chain, whether it is a layer 1, rollup, or app-chain, allowing that chain to communicate seamlessly. The open design of the Hyperlane protocol is known as Permissionless Interoperability (PI). Chains deployed by instutitions other than the Hyperlane core team are referred to as 'PI chains'.
+Hyperlane can be deployed by anyone to any chain, whether it is a layer 1, rollup, or app-chain, allowing that chain to communicate seamlessly. The open design of the Hyperlane protocol is known as Permissionless Interoperability (PI). Chains deployed by institutions other than the Hyperlane core team are referred to as 'PI chains'.
 
 ## Relayer
 
-The [Relayer](../protocol/agents/relayer.mdx) is a Hyperlane [agents](glossary.mdx#agent) responsible for delivering messages from their origin chain(s) to their destination chain(s).
+The [Relayer](../protocol/agents/relayer.mdx) is a Hyperlane [agent](glossary.mdx#agent) responsible for delivering messages from their origin chain(s) to their destination chain(s).
 
 Relayers are untrusted, and anyone can operate a relayer.
 

--- a/docs/reference/messaging/send.mdx
+++ b/docs/reference/messaging/send.mdx
@@ -9,7 +9,7 @@ import SimpleMessagingDiagram from "@site/src/diagrams/messaging-simple.md";
 
 To send interchain messages, developers call `Mailbox.dispatch()`.
 
-This function takes as parameters the message contents, the destination chain ID, and the recipient address. Each message get inserted as a leaf into an [incremental merkle tree](https://medium.com/@josephdelong/ethereum-2-0-deposit-merkle-tree-13ec8404ca4f) stored by the `Mailbox`. Hyperlane's proof of stake protocol uses this merkle tree to verify fraud proofs.
+This function takes as parameters the message contents, the destination chain ID, and the recipient address. Each message gets inserted as a leaf into an [incremental merkle tree](https://medium.com/@josephdelong/ethereum-2-0-deposit-merkle-tree-13ec8404ca4f) stored by the `Mailbox`. Hyperlane's proof of stake protocol uses this merkle tree to verify fraud proofs.
 
 <SimpleMessagingDiagram />
 

--- a/docs/reference/registries.mdx
+++ b/docs/reference/registries.mdx
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Hyperlane can be deployed to anywhere by anyone. But for those deployments to be useful, their details must be well known. Registries are collections of chain metadata, contract addresses, and other useful information for interacting with Hyperlane contracts and tools. There is a [canonical registry](https://github.com/hyperlane-xyz/hyperlane-registry) maintained by the Hyperlane core team. The [CLI](/docs/reference/cli.mdx), the [Explorer](https://explorer.hyperlane.xyz), and other tools can use registry data.
+Hyperlane can be deployed anywhere by anyone. But for those deployments to be useful, their details must be well known. Registries are collections of chain metadata, contract addresses, and other useful information for interacting with Hyperlane contracts and tools. There is a [canonical registry](https://github.com/hyperlane-xyz/hyperlane-registry) maintained by the Hyperlane core team. The [CLI](/docs/reference/cli.mdx), the [Explorer](https://explorer.hyperlane.xyz), and other tools can use registry data.
 
 ## Canonical registry
 


### PR DESCRIPTION
1. docs/reference/glossary.mdx
- Chains deployed by instutitions other than
+ Chains deployed by institutions other than

- is a Hyperlane [agents]
+ is a Hyperlane [agent]
Reason:
Fixed spelling of "institutions"
Reason: Fixed singular/plural agreement - "is a" requires a singular noun, not plural "agents".

2. docs/reference/registries.mdx
- Hyperlane can be deployed to anywhere by anyone
+ Hyperlane can be deployed anywhere by anyone
Reason: Removed redundant preposition "to" as "anywhere" already implies location
Improves grammatical correctness and makes the sentence more concise

3. docs/reference/messaging/send.mdx
- Each message get inserted
+ Each message gets inserted
Reason: Added "s" to "get" for proper subject-verb agreement with singular subject "message".
