### PR TITLE
Docs: AVS Guide Correction 

### DIFF
--- a/docs/guides/avs-operator-guide.mdx
+++ b/docs/guides/avs-operator-guide.mdx
@@ -56,7 +56,7 @@ Your AVS signing key can be reused across multiple validators and doesn't requir
 
 ### Confirming registration
 
-To confirm you are registered on mainnet, run `hyperlane avs check --chain ethereum --operatorAddress <AVS_SIGNING_ADDRESS>` using the Hyperlane CLI and see if your validator address is there. This query may take a few minutes to complete.
+To confirm you are registered on mainnet, run `hyperlane avs check --chain ethereum --operatorAddress <EIGENLAYER_OPERATOR_ADDRESS>` using the Hyperlane CLI and see if your validator address is there. This query may take a few minutes to complete.
 
 Additionally, you can search your address under the `operatorRegistry` function [on Etherscan](https://etherscan.io/address/0x272CF0BB70D3B4f79414E0823B426d2EaFd48910#readProxyContract#F12) or check on EigenLayer's UI for [Ethereum](https://app.eigenlayer.xyz/avs/0xe8e59c6c8b56f2c178f63bcfc4ce5e5e2359c8fc) or [Holesky](https://holesky.eigenlayer.xyz/avs/0xc76e477437065093d353b7d56c81ff54d167b0ab).
 


### PR DESCRIPTION
In the AVS guide under the Confirming Registration section it shows the command to check registration as:
`hyperlane avs check --chain ethereum --operatorAddress <AVS_SIGNING_ADDRESS>`

When it should really be:
`hyperlane avs check --chain ethereum --operatorAddress <EIGENLAYER_OPERATOR_ADDRESS>`
