### PR TITLE
fix: log formatting is defined by `log.format`

### DIFF
--- a/docs/operate/config-reference.mdx
+++ b/docs/operate/config-reference.mdx
@@ -1070,7 +1070,7 @@ export HYP_METRICSPORT=9090
 </TabItem>
 </Tabs>
 
-## log.fmt
+## log.format
 
 **Description:** Configuration for the log module. This controls logging.
 
@@ -1083,13 +1083,13 @@ export HYP_METRICSPORT=9090
 <Tabs groupId="config-reference">
 <TabItem value="arg" label="As Arg" default>
 ```bash
---log.fmt pretty
+--log.format pretty
 ```
 </TabItem>
 
 <TabItem value="env" label="As Env">
 ```bash
-export HYP_LOG_FMT="pretty"
+export HYP_LOG_FORMAT="pretty"
 ```
 </TabItem>
 
@@ -1097,7 +1097,7 @@ export HYP_LOG_FMT="pretty"
 ```json
 {
     "log": {
-        "fmt": "pretty"
+        "format": "pretty"
     }
 }
 ```


### PR DESCRIPTION
instad of `log.fmt`