### PR TITLE
Fix Typo

### DIFF
--- a/docs/production.mdx
+++ b/docs/production.mdx
@@ -4,7 +4,7 @@ To launch your Hyperlane deployment into a production environment, follow these 
 
 ### 1. Core Deployment
 
-To being you'll need to set up and productionize the core components of your Hyperlane deployment.
+To being you'll need to set up and production the core components of your Hyperlane deployment.
 
 - [Update Mailbox Default ISM](/guides/update-mailbox-default-ism.mdx): Update the Interchain Security Module (ISM) associated with the Mailbox contract. The ISM acts as a critical security layer, verifying messages between chains. Ensure that the default ISM settings align with your security requirements.
 - [Transfer Mailbox Ownership](/guides/transfer-mailbox-ownership.mdx): Transfer ownership of the Mailbox contract to a production-ready owner account. This step secures the Mailbox by ensuring only trusted parties have control over its configuration.


### PR DESCRIPTION
Changes Made:
- Corrected the term "productionize" to "production" for accuracy and consistency.

Why This Is Useful:
- Ensures the correct use of terminology.
- Improves clarity and maintains consistency throughout the project.
