### PR TITLE
feat: update registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@docusaurus/theme-mermaid": "3.0.1",
     "@easyops-cn/docusaurus-search-local": "^0.37.4",
     "@hyperlane-xyz/core": "5.8.3",
-    "@hyperlane-xyz/registry": "6.3.0",
+    "@hyperlane-xyz/registry": "6.9.0",
     "@hyperlane-xyz/sdk": "7.3.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",

--- a/src/components/DefaultValidators.tsx
+++ b/src/components/DefaultValidators.tsx
@@ -14,7 +14,7 @@ export default function DefaultValidators({ environment }: DefaultValidatorsProp
     <>
       {chainNames.map((chain) => {
         const config = defaultMultisigConfigs[chain];
-        if (!config || (environment === 'mainnet' && config.validators.length <= 1)) return null;
+        if (!config) return null;
 
         const { name, displayName, domainId } = chainMetadata[chain];
 

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -1,5 +1,5 @@
 import { chainAddresses, chainMetadata } from "@hyperlane-xyz/registry";
-import type { ChainMetadata, ChainName } from "@hyperlane-xyz/sdk";
+import { defaultMultisigConfigs, type ChainMetadata, type ChainName } from "@hyperlane-xyz/sdk";
 import { useMemo } from "react";
 
 const ABACUS_WORKS_DEPLOYER_NAME = "abacus works";
@@ -16,10 +16,13 @@ export function getAbacusWorksChains(
       ABACUS_WORKS_DEPLOYER_NAME;
     // Filter to only mainnets or testnets
     const isRightChainType = !!metadata.isTestnet === isTestnet;
+    // Filter out Mainnet chains that are deployed but not enrolled in the default ISMs
+    const config = defaultMultisigConfigs[metadata.name];
+    const isEnrolled = !metadata.isTestnet ? config?.validators.length > 1 : true;
     // If required, filter to chains that have a mailbox addresses in the registry
     const hasMailboxAddress =
       !requireMailbox || !!chainAddresses[metadata.name]?.mailbox;
-    return isRightDeployer && isRightChainType && hasMailboxAddress;
+    return isRightDeployer && isRightChainType && hasMailboxAddress && isEnrolled;
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4540,13 +4540,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:6.3.0":
-  version: 6.3.0
-  resolution: "@hyperlane-xyz/registry@npm:6.3.0"
+"@hyperlane-xyz/registry@npm:6.9.0":
+  version: 6.9.0
+  resolution: "@hyperlane-xyz/registry@npm:6.9.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: fe568c8ee2152eaac8531727bd960434a9a2544beed797311be3159b3ab04b355b1897f259d192edc8d0dd53b8b34a5af10e44221744ade3a4ed0c4d5461d7f0
+  checksum: e416907df2d200df260e76dafc45e4171cda35185a771e839a2dfbaf4c6df3753c5d97c7eaf5f465957da35ee64ba3cf83a611da4319adb4bbbf51d731ab46ba
   languageName: node
   linkType: hard
 
@@ -12592,7 +12592,7 @@ __metadata:
     "@docusaurus/types": "npm:3.0.1"
     "@easyops-cn/docusaurus-search-local": "npm:^0.37.4"
     "@hyperlane-xyz/core": "npm:5.8.3"
-    "@hyperlane-xyz/registry": "npm:6.3.0"
+    "@hyperlane-xyz/registry": "npm:6.9.0"
     "@hyperlane-xyz/sdk": "npm:7.3.0"
     "@mdx-js/react": "npm:^3.0.0"
     "@types/react": "npm:^18.2.37"


### PR DESCRIPTION
- update registry
- update `getAbacusWorksChains` to filter out mainnets that are not yet live