### PR TITLE
fix: Correct "in to" to "into" in configuration instructions

### DIFF
--- a/docs/guides/quickstart-validator.mdx
+++ b/docs/guides/quickstart-validator.mdx
@@ -87,7 +87,7 @@ To learn more about all the parameters you can change, read the [agent configura
 
 Unless you are running Docker on Linux, you will also need to update the agent configuration for your network. This is because Docker does not support the [`host` network mode](https://docs.docker.com/network/drivers/host/) on Mac, Windows or Windows Server.
 
-To do this, navigate to the agent-configuration at `$CONFIG_FILES` and replace all instances of "localhost" or "127.0.0.1" in to `host.docker.internal`. For example:
+To do this, navigate to the agent-configuration at `$CONFIG_FILES` and replace all instances of "localhost" or "127.0.0.1" into `host.docker.internal`. For example:
 
 ```json
 ...


### PR DESCRIPTION
Replaced the incorrect usage of "in to" with "into" in the phrase "replace all instances of 'localhost' or '127.0.0.1' into" within the configuration instructions.

Explanation:
- "Into" is used to describe movement or transformation of something into another state or position, which is the correct context here as the instructions guide the user to replace one IP address with another.
- "In to" represents two separate words with distinct meanings and is often used in idiomatic expressions, such as "turn oneself in to the police." However, this does not apply to the current context.

By correcting this usage, the text aligns with proper grammar and improves clarity for users following the setup process.