### PR TITLE
Fix: Removed unnecessary comma in "For, instance" phrasing

### DIFF
--- a/docs/operate/validators/monitoring-alerting.mdx
+++ b/docs/operate/validators/monitoring-alerting.mdx
@@ -8,7 +8,7 @@ We recommend using Prometheus to scrape these metrics and Grafana to visualize t
 
 :::info
 
-If running as a Docker image, make sure to port-forward the metrics endpoint port. For, instance, to forward port 9090 on the local port 80, add the following flag to your `docker run` command: `-p 9090:80`
+If running as a Docker image, make sure to port-forward the metrics endpoint port. For instance, to forward port 9090 on the local port 80, add the following flag to your `docker run` command: `-p 9090:80`
 
 :::
 


### PR DESCRIPTION
The phrase "For, instance" contained an unnecessary comma, making the sentence less fluid. Updated the text to remove the comma, improving readability and maintaining consistency with professional documentation standards.

- Original: "For, instance, to forward port 9090 on the local port 80..."
- Fixed: "For instance, to forward port 9090 on the local port 80..."