### PR TITLE
Fix typo: "for, instance" -> "for instance"

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -81,7 +81,7 @@ Validators use the [`MerkleTreeHook.latestCheckpoint()`](https://github.com/hype
 ## Community & Contributions
 
 **How can I join the Hyperlane community?**  
-You can join the [Discord](http://discord.gg/hyperlane) or follow Hyperlane on [Twitter](http://twitter.com/hyperlane), where you can find a growing community of developers and enthusiasts to chat about the interchain future.
+You can join the [Discord](http://discord.gg/hyperlane) or follow Hyperlane on [Twitter](http://x.com/hyperlane), where you can find a growing community of developers and enthusiasts to chat about the interchain future.
 
 **I'm interested in working on Hyperlane. Where can I see job openings?**  
 Check out our open roles [here](https://jobs.lever.co/Hyperlane).

--- a/docs/operate/validators/monitoring-alerting.mdx
+++ b/docs/operate/validators/monitoring-alerting.mdx
@@ -8,7 +8,7 @@ We recommend using Prometheus to scrape these metrics and Grafana to visualize t
 
 :::info
 
-If running as a Docker image, make sure to port-forward the metrics endpoint port. For, instance, to forward port 9090 on the local port 80, add the following flag to your `docker run` command: `-p 9090:80`
+If running as a Docker image, make sure to port-forward the metrics endpoint port. For instance, to forward port 9090 on the local port 80, add the following flag to your `docker run` command: `-p 9090:80`
 
 :::
 


### PR DESCRIPTION
Fix typo: "for, instance" -> "for instance"
