### PR TITLE
Fix spelling errors

### DIFF
--- a/docs/guides/deploy-warp-route-UI.mdx
+++ b/docs/guides/deploy-warp-route-UI.mdx
@@ -114,7 +114,7 @@ To improve the user experience, you could provide some native gas tokens via a f
 
 [Superbridge](https://superbridge.app) is a custom bridge provider, they manage bridge frontends for hundreds of rollups, various tokens and different ecosystems.
 
-Getting a managed Superbridge for your warp route is a hassle free approach to operating your bridge. A few of their most popular Hyperlane powered bridges are [Renzo's ezETH bridge](https://renzo.superbridge.app) and [Elixir's deUSD bridge](https://elixir.superbridge.app). With a managed bridge instance, Superbridge will handle hosting, theming, upgrades & user support requests for your warp route.
+Getting a managed Superbridge for your warp route is a hassle-free approach to operating your bridge. A few of their most popular Hyperlane powered bridges are [Renzo's ezETH bridge](https://renzo.superbridge.app) and [Elixir's deUSD bridge](https://elixir.superbridge.app). With a managed bridge instance, Superbridge will handle hosting, theming, upgrades & user support requests for your warp route.
 
 They've also built a handy feature that allows for self-service testing of recently deployed warp routes.
 

--- a/docs/guides/developer-tips/unit-testing.mdx
+++ b/docs/guides/developer-tips/unit-testing.mdx
@@ -1,8 +1,8 @@
 # Unit testing - EVM
 
-Unit testing can prove to be challenging for a multi-chain setup with Foundry. Hence, we've provided a lightweight test environment `MockHyperlaneEnvironment` for you to unit test your cross-chain app while avoiding the need to fork multiple networks.
+Unit testing can prove to be challenging for a multichain setup with Foundry. Hence, we've provided a lightweight test environment `MockHyperlaneEnvironment` for you to unit test your cross-chain app while avoiding the need to fork multiple networks.
 
-Most multi-chain apps will be built on top of our Mailbox contract. So, we've abstracted away the details of a deployed mailbox with a `MockMailbox` and our environment contains an `originMailbox` and a `destinationMailbox` on the same chain. Internally, we store the messages arriving to the destination in the `inboundMessages` mapping on the destination mailbox. We simulate message delivery by enqueuing messages and increment the `inboundProcessedNonce` with `MockMailbox.processNextInboundMessage()`.
+Most multichain apps will be built on top of our Mailbox contract. So, we've abstracted away the details of a deployed mailbox with a `MockMailbox` and our environment contains an `originMailbox` and a `destinationMailbox` on the same chain. Internally, we store the messages arriving to the destination in the `inboundMessages` mapping on the destination mailbox. We simulate message delivery by enqueuing messages and increment the `inboundProcessedNonce` with `MockMailbox.processNextInboundMessage()`.
 
 The setup for the simple messaging forge test is as following:
 


### PR DESCRIPTION
- Corrected "multi-chain" to "multichain" in `unit-testing.mdx`.
- Added a hyphen to "hassle-free" in `deploy-warp-route-UI.mdx`.