### PR TITLE
fix typo of manage-warp-route-limits.mdx

### DIFF
--- a/docs/guides/manage-warp-route-limits.mdx
+++ b/docs/guides/manage-warp-route-limits.mdx
@@ -28,6 +28,6 @@ There are three actions that should be set on the `MasterMinter` contract to be 
 1. **Remove the previous test controller:**: 
 - As the owner, remove the previous test controller via the [`removeController(address _controller)` function](https://github.com/circlefin/stablecoin-evm/blob/master/contracts/minting/Controller.sol#L87C14-L87C51)
 2. **Set the controller and minter:**
-- As the owner, you should set the controller and minter via the [`configureController(address controller, address worker)` funcition](https://github.com/circlefin/stablecoin-evm/blob/master/contracts/minting/Controller.sol#L70). The controller can be the same as the owner, the minter should be the warp route address.
+- As the owner, you should set the controller and minter via the [`configureController(address controller, address worker)` function](https://github.com/circlefin/stablecoin-evm/blob/master/contracts/minting/Controller.sol#L70). The controller can be the same as the owner, the minter should be the warp route address.
 3. **Set the mint limit for the minter:**
 - As the controller, you should set the mint limit for the minter via the [`configureMinter(uint256 _newAllowance)` function](https://github.com/circlefin/stablecoin-evm/blob/master/contracts/minting/MintController.sol#L116). This limit is not being continuously reset, so either set it to a sufficiently large value (like `cast max-uint`) or monitor the usage and adjust accordingly.


### PR DESCRIPTION
# Fix Typo in manage-warp-route-limits.mdx

## Description
This pull request fixes a typo in the `manage-warp-route-limits.mdx` file to enhance the clarity and professionalism of the documentation.

### Details of the Fix
- Corrected the word **"funcition"** to **"function"** in the section detailing the `configureController` method.

## Why This Change?
Accurate documentation ensures better comprehension and usability for developers. Fixing typos helps maintain the quality and professionalism of the project.

## Checklist
- [x] Typo has been corrected.
- [x] Documentation is clear and error-free.
- [x] Ready for review and merge.

---

Feel free to review and suggest any additional changes if needed. Thank you!
