### PR TITLE
chore: improve clarity of Warp Routes types and examples

### DIFF
--- a/docs/guides/deploy-warp-route.mdx
+++ b/docs/guides/deploy-warp-route.mdx
@@ -16,10 +16,10 @@ This section provides a step-by-step walkthrough for creating an interchain toke
 To deploy the route, you will need a Warp Route deployment config file. A valid config will specify:
 
 - Which token, on which chain, is this Warp Route being created for?
-- _Optional:_ Hyperlane connection details including contract addresses for the [mailbox](/docs/reference/messaging/messaging-interface.mdx), [interchain gas](/docs/reference/hooks/interchain-gas.mdx), and [interchain security modules](/docs/reference/ISM/specify-your-ISM.mdx).
-- _Optional:_ The token standard - this includes fungible tokens using ERC20 or NFTs using ERC721, as well as ERC4626 yield-bearing tokens. Note ERC721 support is experimental and some Hyperlane tooling won't work for NFTs yet.
+- _Optional:_ Hyperlane connection details, such as contract addresses for the [Mailbox](/docs/reference/messaging/messaging-interface.mdx), [Interchain Gas](/docs/reference/hooks/interchain-gas.mdx), and [Interchain Security Modules](/docs/reference/ISM/specify-your-ISM.mdx).
+- _Optional:_ Token standard, including ERC20 (fungible tokens), ERC721 (NFTs), and ERC4626 (yield-bearing tokens). Note ERC721 support is experimental and some Hyperlane tooling won't work for NFTs yet.
 
-The easiest way to create one is with the CLI's config command:
+The easiest way to create a Warp Route deployment config file is with the CLI's config command:
 
 ```bash
 hyperlane warp init
@@ -60,6 +60,14 @@ You may specify the following optional values in your config entries. If no valu
 #### Example
 
 For a minimal Warp deployment config example using local anvil chains, see [`warp-route-deployment.yaml`](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/cli/examples/warp-route-deployment.yaml).
+
+:::tip
+
+- Learn more about Warp Route types and the different configurations in the following sections:
+  - [Warp Route Types](/docs/protocol/warp-routes/warp-routes-types)
+  - [Warp Route Example Usage](/docs/protocol/warp-routes/warp-routes-example-usage)
+
+:::
 
 ### Chain Configurations
 

--- a/docs/protocol/warp-routes/warp-routes-example-usage.mdx
+++ b/docs/protocol/warp-routes/warp-routes-example-usage.mdx
@@ -19,7 +19,7 @@ This type of route should only be used when both networks have native tokens of 
 #### Example Flow
 
 ```
-Transaction Type: Direct Native Transfer
+Transaction Type: Native to Native Transfer
 From: Ethereum (ETH)
 To: inEVM (ETH)
 Amount: 1 ETH

--- a/docs/protocol/warp-routes/warp-routes-example-usage.mdx
+++ b/docs/protocol/warp-routes/warp-routes-example-usage.mdx
@@ -1,6 +1,6 @@
 # Warp Routes: Example Usage
 
-Warp Route combinations allow developers to tailor cross-chain transfers for specific use cases. Below are examples of commonly used combinations and configurations.
+Warp Routes define how assets move between chains, whether as native tokens, synthetic representations, or collateral-backed assets. The choice of route depends on the asset type and the desired behavior on the destination chain.
 
 ## Warp Route Combinations
 
@@ -14,11 +14,12 @@ This type of route should only be used when both networks have native tokens of 
 
 #### Setup
 
-- HypNative contract deployed on both chains.
+- **HypNative** contract deployed on both chains.
 
 #### Example Flow
 
 ```
+Transaction Type: Direct Native Transfer
 From: Ethereum (ETH)
 To: inEVM (ETH)
 Amount: 1 ETH
@@ -43,12 +44,13 @@ This route creates a synthetic representation of a native token on another chain
 
 #### Setup
 
-- HypNative contract deployed on native token chain.
-- HypERC20 (synthetic) contract deployed on other chain.
+- **HypNative** contract deployed on the origin chain where the native asset exists.
+- **HypERC20** contract deployed on the destination chain where the synthetic token is minted.
 
 #### Example Flow
 
 ```
+Transaction Type: Minting Synthetic Token from Native Token
 From: Celo (CELO)
 To: Optimism (wCELO)
 Amount: 100 CELO
@@ -73,14 +75,15 @@ This route allows for the creation of synthetic tokens based on collateralized E
 
 #### Setup
 
-- HypERC20Collateral contract deployed on ERC20 chain.
-- HypERC20 (synthetic) contract deployed on other chain.
+- **Collateral contract (HypERC20Collateral)** is deployed on the source chain where the original asset exists.
+- **Synthetic contract (HypERC20)** is deployed on the destination chain, where the asset is minted.
 
 #### Example Flow
 
 ```
-From: Ethereum (USDC)
-To: Arbitrum (wUSDC)
+Transaction Type: Minting Synthetic Token from Collateral Token
+From: Ethereum (USDC - Original Asset) - Collateral Source
+To: Arbitrum (wUSDC - Minted Synthetic Asset) - Synthetic Destination
 Amount: 1000 USDC
 ```
 

--- a/docs/protocol/warp-routes/warp-routes-types.mdx
+++ b/docs/protocol/warp-routes/warp-routes-types.mdx
@@ -28,7 +28,7 @@ See [the implementation](https://github.com/hyperlane-xyz/hyperlane-monorepo/blo
 
 ### Collateral-Backed ERC20 Warp Routes
 
-Implemented in `HypERC20Collateral.sol`, collateral warp routes enable the transfer of ERC20 tokens across chains by locking them as collateral.
+Implemented in `HypERC20Collateral.sol`, collateral warp routes enable ERC20 tokens to be locked as collateral on the source chain and then used to mint a synthetic representation on the destination chain.
 
 #### Features
 
@@ -41,7 +41,7 @@ See [the implementation](https://github.com/hyperlane-xyz/hyperlane-monorepo/blo
 
 ### Synthetic ERC20 Warp Routes
 
-Implemented in `HypERC20.sol`, synthetic warp routes create new tokens on destination chains that represent tokens from the origin chain.
+Implemented in `HypERC20.sol`, synthetic warp routes mint new tokens on the destination chain that represent the original tokens from the source chain. The original tokens are not transferred but remain locked.
 
 #### Features
 


### PR DESCRIPTION
## Key changes:
- Update warp route examples section with transaction types
- Enhance the collateral backed and synthetic warp route descriptions on Example usage & warp route types
- Add warp route reference links to the bridge a token guide