### PR TITLE
the mkdir command references quickstart-validator.mdx

### DIFF
--- a/docs/guides/quickstart-validator.mdx
+++ b/docs/guides/quickstart-validator.mdx
@@ -175,7 +175,7 @@ docker pull --platform linux/amd64 gcr.io/abacus-labs-dev/hyperlane-agent:agents
 Before running, ensure that all directories you need to mount are present. This may involve creating `hyperlane_db_validator_<your_chain_name>` if it does not exist yet.
 
 ```sh
-mkdir -p hyperlane_db_validator_<your_chain_name>
+mkdir -p hyperlane_db_relayer
 ```
 
 Finally, run the validator:


### PR DESCRIPTION
In the "Run (Using Docker)" section, the mkdir command references a validator directory instead of a relayer directory