### PR TITLE
fix: improve agents overview page and mermaid diagrams line return

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This command generates static content into the `build` directory and can be serv
 
 ### Deployment
 
-Vercel Github Action is used to deploy the website. The action is triggered on every push to the `main` branch.
+Vercel GitHub Action is used to deploy the website. The action is triggered on every push to the `main` branch.
 
 ## Contribution Guidelines
 

--- a/docs/deploy-hyperlane.mdx
+++ b/docs/deploy-hyperlane.mdx
@@ -193,7 +193,7 @@ Make sure your metadata is complete:
 - add the api url `gnosisSafeTransactionServiceUrl` if you have a gnosis safe service
 - lint the yaml files and order alphabetically
 
-### Commit to Github
+### Commit to GitHub
 
 First, navigate to your local instance of the registry and commit changes
 

--- a/docs/guides/create-custom-hook-and-ism.mdx
+++ b/docs/guides/create-custom-hook-and-ism.mdx
@@ -56,7 +56,7 @@ flowchart TB
       C_H[AbstractMessageIdAuthorizedIsm]
       Sender -- "dispatch(..., metadata){value}" --> M_O
 
-      M_O -. "postDispatch(metadata, ...)\n{value - fee}" ..-> C_H
+      M_O -. "postDispatch(metadata, ...)<br>{value - fee}" ..-> C_H
       C_H -- "externalCall(metadata, message)" --> E_B_O
 
     end

--- a/docs/operate/deploy-with-terraform.mdx
+++ b/docs/operate/deploy-with-terraform.mdx
@@ -1,6 +1,6 @@
 # Deploy with Terraform
 
-For those more familiar with deploying to AWS through infrastructure-as-code tools such as Terraform, we provide an [**example configuration in Github**](https://github.com/hyperlane-xyz/hyperlane-monorepo/tree/main/rust/main/terraform) designed to set up the necessary infrastructure for a Hyperlane Validator on AWS. It automates the creation of resources such as ECS clusters, VPCs, subnets, and security groups required for running a Validator agent.
+For those more familiar with deploying to AWS through infrastructure-as-code tools such as Terraform, we provide an [**example configuration in GitHub**](https://github.com/hyperlane-xyz/hyperlane-monorepo/tree/main/rust/main/terraform) designed to set up the necessary infrastructure for a Hyperlane Validator on AWS. It automates the creation of resources such as ECS clusters, VPCs, subnets, and security groups required for running a Validator agent.
 
 :::caution
 

--- a/docs/operate/overview-agents.mdx
+++ b/docs/operate/overview-agents.mdx
@@ -49,8 +49,8 @@ flowchart LR
       Sender
       M_O[(Mailbox)]
       IGP[InterchainGasPaymaster]
-      Sender -- "dispatch(...)\n{value}" --> M_O
-      M_O -- "postDispatch(..., gasLimit)\n{value}" --> IGP
+      Sender -- "dispatch(...)<br>{value}" --> M_O
+      M_O -- "postDispatch(..., gasLimit)<br>{value}" --> IGP
     end
 
     Relayer((Relayer))

--- a/docs/operate/overview-agents.mdx
+++ b/docs/operate/overview-agents.mdx
@@ -21,7 +21,11 @@ These agents are implemented in Rust and distributed as Docker images and binari
 
 A Hyperlane [Relayer](docs/protocol/agents/relayer.mdx) delivers interchain messages to their recipients.
 
-Relaying is permissionless, and one honest Relayer running between a chain pair is sufficient for ensuring liveness. Running a Relayer is: 1) much more operationally complex than a Validator; 2) not required for securing the network; and 3) only recommended for permissionless deployments of Hyperlane.
+Relaying is permissionless, and one honest Relayer running between a chain pair is sufficient for ensuring liveness. Running a Relayer is:
+
+1. much more operationally complex than a Validator.
+2. not required for securing the network.
+3. only recommended for permissionless deployments of Hyperlane.
 
 Hyperlane Relayers are configured to relay messages between one or more origin chains and destination chains.
 Every Hyperlane message involves two transactions:
@@ -29,7 +33,7 @@ Every Hyperlane message involves two transactions:
 1. To [`dispatch`](docs/reference/messaging/send.mdx) and send a message on the origin chain.
 2. To [`process`](docs/reference/messaging/receive.mdx) and deliver the message on destination chain.
 
-A Relayer's job is to deliver the message on the destination chain. To fulfil this responsibility:
+A Relayer's job is to deliver the message on the destination chain. To fulfill this responsibility:
 
 - The Relayer keeps track of new messages as they come in on the origin chain.
 - It checks the [Interchain Security Module (ISM)](/docs/protocol/ISM/modular-security.mdx) specified by the recipient to gather the necessary metadata to secure the message. For example, it may retrieve Multisig ISM signatures from Validator checkpoint storage.

--- a/docs/operate/validators/run-validators.mdx
+++ b/docs/operate/validators/run-validators.mdx
@@ -376,7 +376,7 @@ flowchart TB
     end
 
     subgraph Cloud
-      aws[(Metadata\nDatabase)]
+      aws[(Metadata<br>Database)]
     end
 
     M_O -. "indexing" .-> Relayer

--- a/docs/protocol/agents/validators.mdx
+++ b/docs/protocol/agents/validators.mdx
@@ -22,7 +22,7 @@ The Validator agent uses two key types: one for signing transactions on the bloc
 
 For messages using a [Multisig ISM](../../reference/ISM/multisig-ISM-interface.mdx), validators read the current merkle root by calling `MerkleTreeHook.latestCheckpoint()`.
 
-Validators use the `MerkleTreeHook.latestCheckpoint() function to determine when new transactions need to be indexed. This polling mechanism ensures validators can start signing new messages without the need to backfill the entire tree.
+Validators use the `MerkleTreeHook.latestCheckpoint()` function to determine when new transactions need to be indexed. This polling mechanism ensures validators can start signing new messages without the need to backfill the entire tree.
 
 ### Multisig ISM Prerequisites
 

--- a/docs/protocol/interchain-gas-payment.mdx
+++ b/docs/protocol/interchain-gas-payment.mdx
@@ -10,8 +10,8 @@ flowchart LR
       Sender
       M_O[(Mailbox)]
       IGP[InterchainGasPaymaster]
-      Sender -- "dispatch(...)\n{value}" --> M_O
-      M_O -- "postDispatch(..., gasLimit)\n{value}" --> IGP
+      Sender -- "dispatch(...)<br>{value}" --> M_O
+      M_O -- "postDispatch(..., gasLimit)<br>{value}" --> IGP
     end
 
     Relayer((Relayer))
@@ -37,8 +37,8 @@ flowchart LR
       Sender
       M_O[(Mailbox)]
       IGP[InterchainGasPaymaster]
-      Sender -- "dispatch(...)\n{value}" --> M_O
-      M_O -- "postDispatch(..., gasLimit)\n{value}" --> IGP
+      Sender -- "dispatch(...)<br>{value}" --> M_O
+      M_O -- "postDispatch(..., gasLimit)<br>{value}" --> IGP
     end
 
     Relayer((Relayer))

--- a/docs/reference/applications/interchain-account.mdx
+++ b/docs/reference/applications/interchain-account.mdx
@@ -24,9 +24,9 @@ flowchart TB
     end
 
     Sender -- "callRemote(destination, recipient, call)" --> A_O
-    A_O -- "dispatch(destination, router, \n[sender, recipient, call])" --> M_O
+    A_O -- "dispatch(destination, router, <br>[sender, recipient, call])" --> M_O
     M_O -. "relay" .- M_D
-    M_D -- "handle(origin, router, \n[sender, recipient, call])" --> A_D
+    M_D -- "handle(origin, router, <br>[sender, recipient, call])" --> A_D
     A_D == "interchainAccount(origin, sender)" ==> SenderAccount
     SenderAccount -- "call" --> Recipient
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -4,7 +4,7 @@
 
 The Hyperlane CLI is the official command-line tool for deploying Hyperlane contracts to new chains. It also includes utilities for interacting with deployed contracts and registries.
 
-The published version is available [on NPM](https://www.npmjs.com/package/@hyperlane-xyz/cli). The source is available [on Github in the monorepo](https://github.com/hyperlane-xyz/hyperlane-monorepo/tree/main/typescript/cli).
+The published version is available [on NPM](https://www.npmjs.com/package/@hyperlane-xyz/cli). The source is available [on GitHub in the monorepo](https://github.com/hyperlane-xyz/hyperlane-monorepo/tree/main/typescript/cli).
 
 ## Setup
 

--- a/docs/reference/hooks/overview.mdx
+++ b/docs/reference/hooks/overview.mdx
@@ -14,8 +14,8 @@ flowchart TB
       M_O[(Mailbox)]
       Hook[IPostDispatchHook]
 
-      Sender -- "dispatch(..., metadata, hook)\n{value}" --> M_O
-      M_O -- "postDispatch(message, metadata)\n{value}" --> Hook
+      Sender -- "dispatch(..., metadata, hook)<br>{value}" --> M_O
+      M_O -- "postDispatch(message, metadata)<br>{value}" --> Hook
     end
 ```
 
@@ -118,8 +118,8 @@ flowchart LR
       Sender -- "dispatch(..., metadata){value}" --> M_O
 
       M_O -. "fee = quoteDispatch(...)" .- R_H
-      M_O -- "postDispatch(metadata, ...)\n{fee}" --> R_H
-      M_O -. "postDispatch(metadata, ...)\n{value - fee}" ..-> D_H
+      M_O -- "postDispatch(metadata, ...)<br>{fee}" --> R_H
+      M_O -. "postDispatch(metadata, ...)<br>{value - fee}" ..-> D_H
     end
 ```
 

--- a/docs/reference/messaging/send.mdx
+++ b/docs/reference/messaging/send.mdx
@@ -132,8 +132,8 @@ flowchart LR
       Sender -- "dispatch(...){value}" --> M_O
 
       M_O -. "fee = quoteDispatch(...)" .- R_H
-      M_O -- "postDispatch(...)\n{fee}" --> R_H
-      M_O -- "postDispatch(...)\n{value - fee}" --> D_H
+      M_O -- "postDispatch(...)<br>{fee}" --> R_H
+      M_O -- "postDispatch(...)<br>{value - fee}" --> D_H
     end
 ```
 

--- a/docs/reference/registries.mdx
+++ b/docs/reference/registries.mdx
@@ -18,11 +18,11 @@ However, community members are encouraged to add their own deployments to this c
 
 ## Custom registries
 
-As long as the registry conforms to the same layout and file schemas as the canonical registry, any Github repository URL or local file path can be used instead.
+As long as the registry conforms to the same layout and file schemas as the canonical registry, any GitHub repository URL or local file path can be used instead.
 
 The CLI has two command line arguments for configuring the registry it uses:
 
-- The `--registry` flag sets the primary registry and uses the default Github registry if not set
+- The `--registry` flag sets the primary registry and uses the default GitHub registry if not set
 - The `--overrides` flag sets an optional additional path which can be useful for forcing specific overrides of the default data, for example to use a different RPC URL in a chain's metadata.
 
 Once your custom registry additions/updates are complete and tested, consider opening a pull request to the canonical registry so that others can benefit from your deployments.

--- a/src/diagrams/accounts-implementation.md
+++ b/src/diagrams/accounts-implementation.md
@@ -14,9 +14,9 @@ flowchart TB
     end
 
     Sender -- "dispatch(destination, recipient, call)" --> A_O
-    A_O -- "dispatch(destination, router, \n[sender, recipient, call])" --> M_O
+    A_O -- "dispatch(destination, router, <br>[sender, recipient, call])" --> M_O
     M_O -. "relay" .- M_D
-    M_D -- "handle(origin, router, \n[sender, recipient, call])" --> A_D
+    M_D -- "handle(origin, router, <br>[sender, recipient, call])" --> A_D
     A_D == "interchainAccount(origin, sender)" ==> SenderAccount
     SenderAccount -- "call(data)" --> Recipient
 ```

--- a/src/diagrams/multisig-pos-ism.md
+++ b/src/diagrams/multisig-pos-ism.md
@@ -12,7 +12,7 @@ flowchart TB
     end
 
     subgraph Cloud
-      aws[(Metadata\nDatabase)]
+      aws[(Metadata<br>Database)]
     end
 
     M_O -. "indexing" .-> Relayer

--- a/src/diagrams/queries-implementation.md
+++ b/src/diagrams/queries-implementation.md
@@ -13,12 +13,12 @@ flowchart TB
     end
 
     Sender -- "query(destination, recipient, data, callback)" --> Q_O
-    Q_O -- "dispatch(destination, router, \n[sender, recipient, data, callback])" --> M_O
+    Q_O -- "dispatch(destination, router, <br>[sender, recipient, data, callback])" --> M_O
     M_O -. "relay" .- M_D
-    M_D -- "handle(origin, router, \n[sender, recipient, data, callback])" --> Q_D
+    M_D -- "handle(origin, router, <br>[sender, recipient, data, callback])" --> Q_D
     Q_D -- "call(data)" --> Recipient
     Recipient -- "result" --> Q_D
-    M_O -- "handle(destination, router, \n[sender, result, callback])" --> Q_O
-    Q_D -- "dispatch(origin, router, \n[sender, result, callback])" --> M_D
+    M_O -- "handle(destination, router, <br>[sender, result, callback])" --> Q_O
+    Q_D -- "dispatch(origin, router, <br>[sender, result, callback])" --> M_D
     Q_O -- "callback(result)" --> Sender
 ```


### PR DESCRIPTION
Mermaid uses `<br>` instead of `\n` for line return

**before:**

<img width="379" alt="image" src="https://github.com/user-attachments/assets/6748106f-3009-473b-8918-c4a19e3af797" />

**after:**

<img width="479" alt="image" src="https://github.com/user-attachments/assets/4b810df2-68ea-4e76-a24c-4055fd99cdf0" />
