### PR TITLE
Fix: typo in sidebar and update external links to HTTPS

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -24,7 +24,7 @@ For inspiration, take a look at some of the pre-built applications built on top 
 - **Interchain Queries**: Lets users make interchain view calls.
 
 **I’m a developer. How can my team build with Hyperlane?**  
-If you’re reading this FAQ, you’ve found the docs which is a great place to start. That said, we know that questions arise during implementation, and we’re happy to help you on your way. The Hyperlane community is regularly active in the [Discord](http://discord.gg/hyperlane). Feedback from developers directly influences the product roadmap.
+If you’re reading this FAQ, you’ve found the docs which is a great place to start. That said, we know that questions arise during implementation, and we’re happy to help you on your way. The Hyperlane community is regularly active in the [Discord](https://discord.gg/hyperlane). Feedback from developers directly influences the product roadmap.
 
 ## Technical Questions
 
@@ -81,7 +81,7 @@ Validators use the [`MerkleTreeHook.latestCheckpoint()`](https://github.com/hype
 ## Community & Contributions
 
 **How can I join the Hyperlane community?**  
-You can join the [Discord](http://discord.gg/hyperlane) or follow Hyperlane on [Twitter](http://x.com/hyperlane), where you can find a growing community of developers and enthusiasts to chat about the interchain future.
+You can join the [Discord](https://discord.gg/hyperlane) or follow Hyperlane on [Twitter](https://x.com/hyperlane), where you can find a growing community of developers and enthusiasts to chat about the interchain future.
 
 **I'm interested in working on Hyperlane. Where can I see job openings?**  
 Check out our open roles [here](https://jobs.lever.co/Hyperlane).

--- a/sidebars.js
+++ b/sidebars.js
@@ -549,7 +549,7 @@ const sidebars = {
             {
               type: "doc",
               id: "reference/addresses/validator-announce",
-              label: "Validator Announe",
+              label: "Validator Announce",
             },
             {
               type: "doc",


### PR DESCRIPTION
- Fixed typo in sidebar navigation: "Validator Announe" → "Validator Announce"
- Updated external links in FAQ page to use HTTPS protocol for improved security