### PR TITLE
docs: fix 404 link in `warp-routes-custom-gas-fast-native.mdx`

### DIFF
--- a/docs/protocol/warp-routes/warp-routes-custom-gas-fast-native.mdx
+++ b/docs/protocol/warp-routes/warp-routes-custom-gas-fast-native.mdx
@@ -57,7 +57,7 @@ Set the custom gas token on yourchain to the newly deployed `ETH` ERC20 receipt 
 
 Use your L2's canonical bridge to transfer 100% of the `ETH` receipt token from ethereum to yourchain.
 
-1. To transfer using the OP stack standard bridge: https://docs.optimism.io/builders/app-developers/bridging/standard-bridge
+1. To transfer using the OP stack standard bridge: https://docs.optimism.io/app-developers/bridging/standard-bridge
 2. To transfer using the arbitrum orbit bridge: https://docs.arbitrum.io/launch-orbit-chain/how-tos/add-orbit-chain-to-bridge-ui
 
 ### 4) Deploy a Native Warp Route


### PR DESCRIPTION
Hi! I fixes a 404 link in the `warp-routes-custom-gas-fast-native.mdx` file. The original link pointing to Optimism's documentation for the OP Stack standard bridge was outdated and has been updated to the correct URL.