### PR TITLE
docs: remove irrelevant code block

### DIFF
--- a/docs/protocol/mailbox.mdx
+++ b/docs/protocol/mailbox.mdx
@@ -67,13 +67,6 @@ The `messageId` is a globally unique message identifier, returned from the `disp
 
 The Mailbox maintains a mapping of already delivered `messageId` values to prevent replay attacks. If a message is received with a `messageId` that has already been delivered, the message is rejected.
 
-<Tabs groupId="lang">
-<TabItem value="sol" label="Solidity">
-
-```solidity file=<rootDir>/node_modules/@hyperlane-xyz/core/contracts/interfaces/IMailbox.sol#L51
-
-```
-
 </TabItem>
 
 </Tabs>


### PR DESCRIPTION
Remove a code block that contains `defaultIsm` because this section of the docs covers something else.

## Screenshot

Current docs

![Screenshot 2025-03-06 at 2 40 34 PM](https://github.com/user-attachments/assets/85d8d40f-9e9e-4d5e-948b-f1537dc0118a)
