### PR TITLE
docs: remove irrelevant code block

### DIFF
--- a/docs/reference/messaging/receive.mdx
+++ b/docs/reference/messaging/receive.mdx
@@ -93,16 +93,6 @@ When a message is received, the Mailbox will verify security with an [Interchain
 
 To query the default ISM address, you can call the `defaultIsm` function.
 
-<Tabs groupId="lang">
-<TabItem value="sol" label="Solidity">
-
-```solidity file=<rootDir>/node_modules/@hyperlane-xyz/core/contracts/interfaces/IMailbox.sol#L53
-
-```
-
-</TabItem>
-</Tabs>
-
 ### Modular Security
 
 To leverage Hyperlane's modular security, message recipients can specify a custom Interchain Security Module to **verify anything** about incoming messages. The Mailbox will defer to this ISM when specified.


### PR DESCRIPTION
This section of the docs refers to `defaultIsm` but the code block is for a `defaultHook`. Seems like there is no mechanism to keep the code blocks up to date with the docs so maybe we should eliminate the code blocks and encourage people to check out the latest codebase for the relevant functions. I'm glossing over these Solidity function definitions in the docs anyway. 

![Screenshot 2025-03-06 at 2 54 01 PM](https://github.com/user-attachments/assets/61ec17bf-ab71-4718-a3f1-bc5fea0436fb)
