### PR TITLE
feat: docs reorg

### DIFF
--- a/docs/deploy-hyperlane.mdx
+++ b/docs/deploy-hyperlane.mdx
@@ -2,7 +2,8 @@
 
 :::info
 
-- This guide will help you deploy Hyperlane to your new chain as quickly as possible for testing, not production. This includes the core mailbox and ISM contracts as well as warp route contracts for assets you’re bridging.
+- This guide is for EVM-compatible chains only.
+- It will walk you through deploying Hyperlane to your new chain as quickly as possible for testing, not production. This includes the core Mailbox and ISM contracts as well as Warp Route contracts for asset bridging.
 - To see which chains are already supported, visit the [Registry](https://github.com/hyperlane-xyz/hyperlane-registry/tree/main/chains).
 - If you need any help, reach out on #developers on Discord or [get in touch](https://forms.gle/KyRTaWvo4XNmNvrq6).
 
@@ -149,7 +150,7 @@ testRecipient: "0xa58462b1943Be1469Ed58db690C78583BA34Fd2E"
 
 :::warning
 
-`eth_getStorageAt()` Compatibility: Some chains may not utilize the [`eth_getStorageAt()`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat) API. If your deployment encounters related issues, refer to the [Troubleshooting Guide](./deploy-hyperlane-troubleshooting#eth_getstorageat-compatibility).
+- `eth_getStorageAt()` Compatibility: Some chains may not utilize the [`eth_getStorageAt()`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat) API. If your deployment encounters related issues, refer to the [Troubleshooting Guide](./deploy-hyperlane-troubleshooting#eth_getstorageat-compatibility).
 
 :::
 
@@ -175,7 +176,7 @@ hyperlane relayer --chains yourchain,sepolia
 
 ## 3. Warp Route
 
-Now that you have a Hyperlane mailbox and core contracts on your chain, it’s time to set up token bridging between your chain and any other Hyperlane chain.
+Now that you have a Hyperlane Mailbox and core contracts on your chain, it’s time to set up token bridging between your chain and any other Hyperlane chain.
 
 Continue on to the [Deploy a Warp Route](/docs/guides/deploy-warp-route.mdx) docs for more details.
 

--- a/docs/deploy-hyperlane.mdx
+++ b/docs/deploy-hyperlane.mdx
@@ -2,7 +2,7 @@
 
 :::info
 
-- This guide is for EVM-compatible chains only.
+- This guide is for **EVM-compatible** chains only.
 - It will walk you through deploying Hyperlane to your new chain as quickly as possible for testing, not production. This includes the core Mailbox and ISM contracts as well as Warp Route contracts for asset bridging.
 - To see which chains are already supported, visit the [Registry](https://github.com/hyperlane-xyz/hyperlane-registry/tree/main/chains).
 - If you need any help, reach out on #developers on Discord or [get in touch](https://forms.gle/KyRTaWvo4XNmNvrq6).

--- a/docs/guides/deploy-warp-route.mdx
+++ b/docs/guides/deploy-warp-route.mdx
@@ -2,6 +2,13 @@ import CliChainsPartial from "/docs/partials/deploy-hyperlane/_cli-chains.mdx";
 
 # How to Bridge a Token with Hyperlane Warp Routes
 
+:::info
+**This guide is for EVM-based chains.** For other environments, check out:
+
+- [SVM Warp Route Guide](/docs/guides/deploy-svm-warp-route.mdx)
+- [EVM ↔ SVM Warp Route Guide](/docs/guides/deploy-evm-svm-warp-route.mdx)
+  :::
+
 This section provides a step-by-step walkthrough for creating an interchain token bridge by deploying Hyperlane Warp Route contracts.
 
 ## Prerequisites

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -4,15 +4,22 @@
 
 Hyperlane is a permissionless interoperability protocol for cross-chain communication across different blockchain environments. It enables message passing and asset transfers across different chains without relying on centralized intermediaries or requiring any permissions.
 
-Hyperlane's permissionless design means that anyone can [deploy hyperlane](https://docs.hyperlane.xyz/docs/deploy-hyperlane) to any blockchain environment, whether it is a layer 1, rollup, or app-chain, and start building cross-chain applications right away—no approvals, no intermediaries. This gives developers full control over how their dApp operates in a multi-chain environment, removing bottlenecks and enabling scalability.
+### Key Features
 
-Designed with modularity in mind, Hyperlane's [Interchain Security Modules (ISM)](https://docs.hyperlane.xyz/docs/protocol/ISM/modular-security) allow developers to configure, compose, and customize their security model according to their application's needs.
+- **Permissionless**: Anyone can [deploy hyperlane](https://docs.hyperlane.xyz/docs/deploy-hyperlane), whether it is a layer 1, rollup, or app-chain, and start building cross-chain applications right away—no approvals, no intermediaries.
+- **Modular Security**: Hyperlane's [Interchain Security Modules (ISM)](https://docs.hyperlane.xyz/docs/protocol/ISM/modular-security) allow developers to configure, compose, and customize their security model according to their application's needs.
+- **Multi-VM Support**: Hyperlane enables cross-chain communication for multiple virtual machines (VMs), including EVM, SVM and CosmWasm. It also supports **cross-VM interactions**, such as EVM ↔ SVM asset transfers.
 
 ## Start Building with Hyperlane
 
 Get started with Hyperlane by exploring deployment guides & key features:
 
-- **[Bridge a token with Hyperlane Warp Routes](/guides/deploy-warp-route.mdx)**: Warp Routes enable seamless cross-chain transfers for native and `ERC20` tokens.
+- **[Bridge any token with Hyperlane Warp Routes](/guides/deploy-warp-route.mdx)**: Warp Routes let you deploy a custom token bridge, enabling any native or `ERC20` token to be transferred across chains.
+
+  - For **EVM-based chains**, use the **[EVM Warp Route Guide](/guides/deploy-warp-route.mdx)**.
+  - For **Solana Virtual Machine (SVM) chains**, see the **[SVM Warp Route Guide](/docs/guides/deploy-svm-warp-route.mdx)**.
+  - For **cross-chain transfers between EVM and SVM**, check out the **[EVM-SVM Warp Route Guide](/docs/guides/deploy-evm-svm-warp-route.mdx)**.
+
 - **[Learn about General Message Passing](./reference/messaging/send.mdx)**: Send arbitrary messages between chains.
 - **Use [Interchain Accounts](https://docs.hyperlane.xyz/docs/reference/applications/interchain-account)**: Execute smart contract calls on remote chains from a single account.
 - **[Deploy Hyperlane to your chain](/deploy-hyperlane.mdx)**: Set up Hyperlane on a new chain.

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -2,9 +2,7 @@
 
 ## What is Hyperlane?
 
-Hyperlane is a permissionless interoperability protocol for cross-chain communication. It enables message passing and asset transfers across different chains without relying on centralized intermediaries or requiring any permissions.
-
-## Why Hyperlane?
+Hyperlane is a permissionless interoperability protocol for cross-chain communication across different blockchain environments. It enables message passing and asset transfers across different chains without relying on centralized intermediaries or requiring any permissions.
 
 Hyperlane's permissionless design means that anyone can [deploy hyperlane](https://docs.hyperlane.xyz/docs/deploy-hyperlane) to any blockchain environment, whether it is a layer 1, rollup, or app-chain, and start building cross-chain applications right away—no approvals, no intermediaries. This gives developers full control over how their dApp operates in a multi-chain environment, removing bottlenecks and enabling scalability.
 
@@ -14,8 +12,8 @@ Designed with modularity in mind, Hyperlane's [Interchain Security Modules (ISM)
 
 Get started with Hyperlane by exploring deployment guides and key features:
 
-- **[Deploy to your chain](/deploy-hyperlane.mdx)**
 - **[Bridge a token](/guides/deploy-warp-route.mdx)**: Learn about [Warp Routes](https://docs.hyperlane.xyz/docs/protocol/warp-routes/warp-routes-overview), which allow native and `ERC20` tokens to move seamlessly across chains
 - **[Learn about General Message Passing](./reference/messaging/send.mdx)**
 - **Use [Interchain Accounts](https://docs.hyperlane.xyz/docs/reference/applications/interchain-account)**: Interchain Accounts enable an account on one chain (e.g., a DAO) to make smart contract calls on remote chains
+- **[Deploy to your chain](/deploy-hyperlane.mdx)**
 - **Join our Ecosystem:** [Discord](https://discord.com/invite/hyperlane), [Twitter](https://x.com/hyperlane)

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -10,10 +10,10 @@ Designed with modularity in mind, Hyperlane's [Interchain Security Modules (ISM)
 
 ## Start Building with Hyperlane
 
-Get started with Hyperlane by exploring deployment guides and key features:
+Get started with Hyperlane by exploring deployment guides & key features:
 
-- **[Bridge a token](/guides/deploy-warp-route.mdx)**: Learn about [Warp Routes](https://docs.hyperlane.xyz/docs/protocol/warp-routes/warp-routes-overview), which allow native and `ERC20` tokens to move seamlessly across chains
-- **[Learn about General Message Passing](./reference/messaging/send.mdx)**
-- **Use [Interchain Accounts](https://docs.hyperlane.xyz/docs/reference/applications/interchain-account)**: Interchain Accounts enable an account on one chain (e.g., a DAO) to make smart contract calls on remote chains
-- **[Deploy to your chain](/deploy-hyperlane.mdx)**
-- **Join our Ecosystem:** [Discord](https://discord.com/invite/hyperlane), [Twitter](https://x.com/hyperlane)
+- **[Bridge a token with Hyperlane Warp Routes](/guides/deploy-warp-route.mdx)**: Warp Routes enable seamless cross-chain transfers for native and `ERC20` tokens.
+- **[Learn about General Message Passing](./reference/messaging/send.mdx)**: Send arbitrary messages between chains.
+- **Use [Interchain Accounts](https://docs.hyperlane.xyz/docs/reference/applications/interchain-account)**: Execute smart contract calls on remote chains from a single account.
+- **[Deploy Hyperlane to your chain](/deploy-hyperlane.mdx)**: Set up Hyperlane on a new chain.
+- **Join our Ecosystem:** [Discord](https://discord.com/invite/hyperlane) | [Twitter](https://x.com/hyperlane)

--- a/docs/protocol/warp-routes/warp-routes-overview.mdx
+++ b/docs/protocol/warp-routes/warp-routes-overview.mdx
@@ -1,18 +1,32 @@
 # Warp Routes
 
-## Overview
+Warp Routes are modular cross-chain asset bridges that enable the transfer of tokens between chains using Hyperlane. Developers can use Hyperlane to permissionlessly deploy Warp Routes to move assets between chains.
 
-Developers can use Hyperlane to permissionlessly deploy Warp Routes - contracts that allow any ERC20, ERC721, or native tokens to move effortlessly between chains.
+They support various asset types, including:
 
-You can combine Warp Routes with a Hyperlane deployment to create economic trade routes between any chain and others already connected through Hyperlane.
+- ERC20 & ERC721 tokens (for EVM-compatible chains)
+- SVM-based assets (for SVM-compatible chains)
+- Native tokens (such as ETH, or other gas tokens)
+
+You can combine Warp Routes with a Hyperlane deployment to create economic routes between any chain and others already connected through Hyperlane.
+
+### Deploy a Warp Route
+
+Warp Routes can be deployed between any set of chains that have Hyperlane deployments.
+
+To deploy a Warp Route head over to the following guides:
+
+- [EVM-based Warp Route](/docs/guides/deploy-warp-route)
+- [SVM-based Warp Route](/docs/guides/deploy-svm-warp-route)
+- [EVM-SVM Warp Route](/docs/guides/deploy-evm-svm-warp-route)
+
+:::tip
+If you would like to create a Warp Route that includes a chain that Hyperlane is not currently deployed on, feel free to [deploy Hyperlane](../../deploy-hyperlane.mdx) yourself!
+:::
 
 ### Modular Security
 
 Like all applications built on top of Hyperlane, Warp Routes have customizable security via [Interchain Security Modules](../../protocol/ISM/modular-security.mdx). This allows Warp Route deployers to configure and enforce custom rules and constraints that the interchain token must follow.
-
-### Deploy a Warp Route
-
-Warp Routes can be deployed between any set of chains that have Hyperlane deployments. If you would like to create a Warp Route that includes a chain that Hyperlane is not currently deployed on, feel free to [deploy hyperlane](../../deploy-hyperlane.mdx) yourself!
 
 ### Warp Route Architecture
 
@@ -22,10 +36,10 @@ The diagram below provides a simplified outline of the process for creating your
 
 ![Warp Route diagram/doodle](/img/warpcontractdiagram.png)
 
-Each Warp Route consists of one contract deployed on every chain that the token can move between. These contracts use the [Mailbox](../mailbox.mdx) to send interchain messages to one another.
+- Each Warp Route consists of one contract deployed on every chain that the token can move between. These contracts use the [Mailbox](../mailbox.mdx) to send interchain messages to one another.
 
-When a user transfers from the _canonical_ origin chain to a _non-canonical_ destination chain, their tokens are locked in a `HypERC20Collateral` contract, which sends a message to the destination chain to mint wrapped tokens.
+- When a user transfers from the _canonical_ origin chain to a _non-canonical_ destination chain, their tokens are locked in a `HypERC20Collateral` contract, which sends a message to the destination chain to mint wrapped tokens.
 
-When a user transfers between non-canonical chains, their wrapped tokens are burned on the origin chain, which sends a message to the destination chain to mint wrapped tokens.
+- When a user transfers between non-canonical chains, their wrapped tokens are burned on the origin chain, which sends a message to the destination chain to mint wrapped tokens.
 
-Finally, if a user transfers from a non-canonical origin chain back to the canonical destination chain, their wrapped tokens are burned on the origin chain, which sends a message to the destination chain to release the tokens locked in the`HypERC20Collateral` contract.
+- Finally, if a user transfers from a non-canonical origin chain back to the canonical destination chain, their wrapped tokens are burned on the origin chain, which sends a message to the destination chain to release the tokens locked in the`HypERC20Collateral` contract.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -408,7 +408,7 @@ const config = {
             type: "docSidebar",
             sidebarId: "getstartedSidebar",
             position: "left",
-            label: "⏩ Get Started",
+            label: "⏩ Home",
           },
           /*
           {

--- a/sidebars.js
+++ b/sidebars.js
@@ -37,35 +37,43 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Warp Routes",
-      link: {
-        type: "doc",
-        id: "protocol/warp-routes/warp-routes-overview",
-      },
+      label: "Applications",
+      collapsed: false,
       collapsible: true,
-      collapsed: true,
       items: [
         {
-          type: "doc",
-          id: "reference/applications/warp-routes",
-          label: "Warp Route Interface",
+          type: "category",
+          label: "Warp Routes",
+          link: {
+            type: "doc",
+            id: "protocol/warp-routes/warp-routes-overview",
+          },
+          collapsible: true,
+          collapsed: true,
+          items: [
+            {
+              type: "doc",
+              id: "reference/applications/warp-routes",
+              label: "Warp Route Interface",
+            },
+            {
+              type: "doc",
+              id: "protocol/warp-routes/warp-routes-types",
+              label: "Warp Route Types",
+            },
+            {
+              type: "doc",
+              id: "protocol/warp-routes/warp-routes-example-usage",
+              label: "Warp Route Example Usage",
+            },
+          ],
         },
         {
           type: "doc",
-          id: "protocol/warp-routes/warp-routes-types",
-          label: "Warp Route Types",
-        },
-        {
-          type: "doc",
-          id: "protocol/warp-routes/warp-routes-example-usage",
-          label: "Warp Route Example Usage",
+          id: "reference/applications/interchain-account",
+          label: "Interchain Accounts",
         },
       ],
-    },
-    {
-      type: "doc",
-      id: "reference/applications/interchain-account",
-      label: "Interchain Accounts",
     },
     {
       type: "category",
@@ -239,6 +247,73 @@ const sidebars = {
           type: "doc",
           id: "deploy-hyperlane-troubleshooting",
           label: "Troubleshooting",
+        },
+      ],
+    },
+    {
+      type: "category",
+      label: "Deployments",
+      items: [
+        {
+          type: "category",
+          label: "Contract Addresses",
+          items: [
+            {
+              type: "doc",
+              id: "reference/addresses/mailbox-addresses",
+              label: "Mailbox",
+            },
+            {
+              type: "doc",
+              id: "reference/addresses/interchain-gas-paymaster",
+              label: "Interchain Gas Paymaster (Hook)",
+            },
+            {
+              type: "doc",
+              id: "reference/addresses/storage-gas-oracle",
+              label: "Storage Gas Oracle",
+            },
+            {
+              type: "doc",
+              id: "reference/addresses/merkle-tree",
+              label: "Merkle Tree (Hook)",
+            },
+            {
+              type: "doc",
+              id: "reference/addresses/validator-announce",
+              label: "Validator Announce",
+            },
+            {
+              type: "doc",
+              id: "reference/addresses/proxy-admin",
+              label: "Proxy Admin",
+            },
+            {
+              type: "doc",
+              id: "reference/addresses/test-recipient",
+              label: "Test Recipient",
+            },
+            {
+              type: "doc",
+              id: "reference/addresses/interchain-account-router",
+              label: "Interchain Account Router",
+            },
+          ],
+        },
+        {
+          type: "doc",
+          id: "reference/default-ism-validators",
+          label: "Default ISM Validators",
+        },
+        {
+          type: "doc",
+          id: "reference/domains",
+          label: "Domains",
+        },
+        {
+          type: "doc",
+          id: "reference/registries",
+          label: "Registries",
         },
       ],
     },
@@ -539,73 +614,6 @@ const sidebars = {
           type: "doc",
           id: "guides/implementation-guide",
           label: "Implementation Guide",
-        },
-      ],
-    },
-    {
-      type: "category",
-      label: "Deployments",
-      items: [
-        {
-          type: "category",
-          label: "Contract Addresses",
-          items: [
-            {
-              type: "doc",
-              id: "reference/addresses/mailbox-addresses",
-              label: "Mailbox",
-            },
-            {
-              type: "doc",
-              id: "reference/addresses/interchain-gas-paymaster",
-              label: "Interchain Gas Paymaster (Hook)",
-            },
-            {
-              type: "doc",
-              id: "reference/addresses/storage-gas-oracle",
-              label: "Storage Gas Oracle",
-            },
-            {
-              type: "doc",
-              id: "reference/addresses/merkle-tree",
-              label: "Merkle Tree (Hook)",
-            },
-            {
-              type: "doc",
-              id: "reference/addresses/validator-announce",
-              label: "Validator Announce",
-            },
-            {
-              type: "doc",
-              id: "reference/addresses/proxy-admin",
-              label: "Proxy Admin",
-            },
-            {
-              type: "doc",
-              id: "reference/addresses/test-recipient",
-              label: "Test Recipient",
-            },
-            {
-              type: "doc",
-              id: "reference/addresses/interchain-account-router",
-              label: "Interchain Account Router",
-            },
-          ],
-        },
-        {
-          type: "doc",
-          id: "reference/default-ism-validators",
-          label: "Default ISM Validators",
-        },
-        {
-          type: "doc",
-          id: "reference/domains",
-          label: "Domains",
-        },
-        {
-          type: "doc",
-          id: "reference/registries",
-          label: "Registries",
         },
       ],
     },

--- a/sidebars.js
+++ b/sidebars.js
@@ -33,11 +33,6 @@ const sidebars = {
           id: "guides/deploy-warp-route",
           label: "Bridge a Token",
         },
-        {
-          type: "doc",
-          id: "deploy-hyperlane-troubleshooting",
-          label: "Troubleshooting",
-        },
       ],
     },
     {
@@ -101,7 +96,6 @@ const sidebars = {
           id: "guides/local-testnet-setup",
           label: "Local Setup: Sending Messages between Anvil Nodes",
         },
-
         {
           type: "category",
           label: "Warp Routes",
@@ -240,6 +234,11 @@ const sidebars = {
           type: "doc",
           id: "guides/create-custom-hook-and-ism",
           label: "Create a Hook/ISM",
+        },
+        {
+          type: "doc",
+          id: "deploy-hyperlane-troubleshooting",
+          label: "Troubleshooting",
         },
       ],
     },

--- a/sidebars.js
+++ b/sidebars.js
@@ -30,11 +30,6 @@ const sidebars = {
       items: [
         {
           type: "doc",
-          id: "deploy-hyperlane",
-          label: "Deploy to a New Chain",
-        },
-        {
-          type: "doc",
           id: "guides/deploy-warp-route",
           label: "Bridge a Token",
         },
@@ -58,7 +53,7 @@ const sidebars = {
         {
           type: "doc",
           id: "reference/applications/warp-routes",
-          label: "Warp Routes Interface",
+          label: "Warp Route Interface",
         },
         {
           type: "doc",
@@ -84,15 +79,29 @@ const sidebars = {
       collapsed: true,
       items: [
         {
-          type: "doc",
-          id: "guides/deploy-warp-route-UI",
-          label: "Deploy a Bridge UI",
+          type: "category",
+          label: "Set Up Hyperlane on your Chain",
+          collapsible: true,
+          collapsed: true,
+          items: [
+            {
+              type: "doc",
+              id: "deploy-hyperlane",
+              label: "Deploy to a New Chain",
+            },
+            {
+              type: "doc",
+              id: "guides/deploy-hyperlane-local-agents",
+              label: "Deploy Hyperlane with Local Agents",
+            },
+          ],
         },
         {
           type: "doc",
           id: "guides/local-testnet-setup",
           label: "Local Setup: Sending Messages between Anvil Nodes",
         },
+
         {
           type: "category",
           label: "Warp Routes",
@@ -100,29 +109,50 @@ const sidebars = {
           collapsed: true,
           items: [
             {
-              type: "doc",
-              id: "protocol/warp-routes/warp-routes-yield-routes",
-              label: "Deploy Yield Routes",
+              type: "category",
+              label: "EVM Warp Routes",
+              collapsible: true,
+              collapsed: true,
+              items: [
+                {
+                  type: "doc",
+                  id: "protocol/warp-routes/warp-routes-yield-routes",
+                  label: "Deploy Yield Routes",
+                },
+                {
+                  type: "doc",
+                  id: "protocol/warp-routes/warp-routes-custom-gas-fast-native",
+                  label: "Fast Native Transfer via Custom Gas Tokens",
+                },
+                {
+                  type: "doc",
+                  id: "guides/extending-warp-route",
+                  label: "Extending a Warp Route",
+                },
+                {
+                  type: "doc",
+                  id: "guides/xerc20-warp-route-guide",
+                  label: "Deploy an xERC20 Warp Route",
+                },
+                {
+                  type: "doc",
+                  id: "guides/manage-warp-route-limits",
+                  label: "Mangaging Warp Route Limits",
+                },
+              ],
             },
             {
-              type: "doc",
-              id: "protocol/warp-routes/warp-routes-custom-gas-fast-native",
-              label: "Fast Native Transfer via Custom Gas Tokens",
-            },
-            {
-              type: "doc",
-              id: "guides/extending-warp-route",
-              label: "Extending a Warp Route",
-            },
-            {
-              type: "doc",
-              id: "guides/xerc20-warp-route-guide",
-              label: "Deploy an xERC20 Warp Route",
-            },
-            {
-              type: "doc",
-              id: "guides/deploy-svm-warp-route",
-              label: "Deploy an SVM Warp Route",
+              type: "category",
+              label: "SVM Warp Routes",
+              collapsible: true,
+              collapsed: true,
+              items: [
+                {
+                  type: "doc",
+                  id: "guides/deploy-svm-warp-route",
+                  label: "Deploy an SVM Warp Route",
+                },
+              ],
             },
             {
               type: "doc",
@@ -131,8 +161,8 @@ const sidebars = {
             },
             {
               type: "doc",
-              id: "guides/manage-warp-route-limits",
-              label: "Mangaging Warp Route Limits",
+              id: "guides/deploy-warp-route-UI",
+              label: "Deploy a Bridge UI for Hyperlane Warp Routes",
             },
           ],
         },
@@ -210,11 +240,6 @@ const sidebars = {
           type: "doc",
           id: "guides/create-custom-hook-and-ism",
           label: "Create a Hook/ISM",
-        },
-        {
-          type: "doc",
-          id: "guides/deploy-hyperlane-local-agents",
-          label: "Deploy Hyperlane with Local Agents",
         },
       ],
     },


### PR DESCRIPTION
- Reorganize sidebar: rename "Getstarted" as Home, move deployments to Home, add VM categorization to Guides/Warp routes
- Update intro 
- Add specific to EVM-based chains warning to guides (bridge a token and deploy to your chain)
