### PR TITLE
feat: update ism section and fixes 

### DIFF
--- a/docs/protocol/ISM/custom-ISM.mdx
+++ b/docs/protocol/ISM/custom-ISM.mdx
@@ -1,9 +1,9 @@
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# Overriding the default ISM
+# Creating Your Own ISM
 
-Developers can specify or override the default ISM by implementing the `ISpecifiesInterchainSecurityModule` interface in their application.
+This page explains how to create your own Interchain Security Module (ISM) for custom message verification.
 
 :::info
 If no ISM is specified, or if the specified ISM is the null address, the default ISM configured on the destination chain's Mailbox will be used.

--- a/docs/protocol/ISM/custom-ISM.mdx
+++ b/docs/protocol/ISM/custom-ISM.mdx
@@ -3,7 +3,7 @@ import TabItem from "@theme/TabItem";
 
 # Creating Your Own ISM
 
-This page explains how to create your own Interchain Security Module (ISM) for custom message verification.
+Developers can specify or override the default ISM by implementing the `ISpecifiesInterchainSecurityModule` interface in their application.
 
 :::info
 If no ISM is specified, or if the specified ISM is the null address, the default ISM configured on the destination chain's Mailbox will be used.

--- a/docs/protocol/ISM/modular-security.mdx
+++ b/docs/protocol/ISM/modular-security.mdx
@@ -12,6 +12,8 @@ Hyperlane is secured by **Interchain Security Modules** (ISMs). ISMs are smart c
 
 ### Standard ISMs
 
+Standard ISMs are pre-built modules developed by the AW team.
+
 | ISM Type            | Description                                                                    | Type     |
 | ------------------- | ------------------------------------------------------------------------------ | -------- |
 | **Multisig ISM**    | Verifies messages through validator consensus                                  | Standard |
@@ -20,6 +22,8 @@ Hyperlane is secured by **Interchain Security Modules** (ISMs). ISMs are smart c
 | **CCIP-Read ISM**   | Verifies messages using off-chain data via EIP-3668                            | Standard |
 
 ### Community ISMs
+
+Community ISMs are developed and maintained by the community to extend ISM capabilities.
 
 | ISM Type              | Description                                                                                                        | Type      |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------ | --------- |
@@ -33,21 +37,27 @@ Hyperlane is secured by **Interchain Security Modules** (ISMs). ISMs are smart c
 
 ### Default vs Custom ISM
 
-Developers can either use the [Mailbox's](../mailbox.mdx) default ISM or specify their own application-specific ISM. Application-specific ISM can be:
+Developers can either use the [Mailbox's](../mailbox.mdx) default ISM or specify their own application-specific ISM.
+
+Application-specific ISM can be:
 
 - **Configured**: Use pre-built ISMs with custom parameters
 - **Composed**: Combine multiple ISMs together like security "legos"
 - **Customized**: Create entirely new ISMs tailored to specific needs
 
+:::info
+The "default ISM" refers to the pre-configured security module on the Mailbox contract (the Multisig ISM) that's used when applications don't specify their own custom ISM.
+:::
+
 #### Configure
 
-Hyperlane defines a set of pre-built ISMs. Developers can deploy any of these contracts "off-the-shelf" and configure them with their own parameters.
+Hyperlane defines a set of [pre-built ISMs](#standard-isms). Developers can deploy any of these contracts "off-the-shelf" and configure them with their own parameters.
 
 For example, application developers that want increased sovereignty over interchain security could deploy a [Multisig ISM](multisig-ISM.mdx) configured with validators sourced from their own community.
 
 #### Compose
 
-ISMs act as "security [legos](https://en.wikipedia.org/wiki/Lego)". Developers can mix and match different ISMs together to encode a security model that best fits their needs.
+ISMs act as "security legos". Developers can mix and match different ISMs together to encode a security model that best fits their needs.
 
 For example, application developers that want additional security could deploy an [Aggregation ISM](aggregation-ISM.mdx) that requires verification by both a [Multisig ISM](multisig-ISM.mdx) configured with validators from the Hyperlane community, **and** a Wormhole ISM that verifies that a quorum of the [Wormhole](https://wormhole.com/) validator set verified the message.
 
@@ -59,6 +69,6 @@ For example, application developers can build ISMs that adjust security models b
 
 :::tip
 
-- Learn how to [Create your own ISM](./custom-ISM.mdx)
+Learn how to [Create your own ISM](./custom-ISM.mdx)
 
 :::

--- a/docs/protocol/ISM/modular-security.mdx
+++ b/docs/protocol/ISM/modular-security.mdx
@@ -8,6 +8,27 @@ Hyperlane is secured by **Interchain Security Modules** (ISMs). ISMs are smart c
 
 <IsmDiagram />
 
+## Available ISMs
+
+### Standard ISMs
+
+| ISM Type            | Description                                                                    | Type     |
+| ------------------- | ------------------------------------------------------------------------------ | -------- |
+| **Multisig ISM**    | Verifies messages through validator consensus                                  | Standard |
+| **Routing ISM**     | Routes verification to different ISMs based on origin chain or message content | Standard |
+| **Aggregation ISM** | Combines multiple ISMs to require verification from several sources            | Standard |
+| **CCIP-Read ISM**   | Verifies messages using off-chain data via EIP-3668                            | Standard |
+
+### Community ISMs
+
+| ISM Type              | Description                                                                                                        | Type      |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ | --------- |
+| Wormhole ISM          | Verifies messages using attestations from Wormhole's guardian network, requiring 13 of 19 guardians for validation | Community |
+| Polygon PoS ISM       | Uses Polygon's state sync mechanism for secure message passing between Ethereum ↔ Polygon PoS                      | Community |
+| Optimistic ISM        | Implements an optimistic verification model with a fraud window where watchers can flag fraudulent messages        | Community |
+| OP Stack ISM          | Uses OP Stack rollup's settlement layer security for messages between Ethereum ↔ OP Stack rollups                  | Community |
+| Arbitrum L2 to L1 ISM | Uses Arbitrum rollup's security properties for messages sent from Arbitrum L2 ↔ Ethereum                           | Community |
+
 ## Core Concepts
 
 ### Default vs Custom ISM
@@ -38,6 +59,6 @@ For example, application developers can build ISMs that adjust security models b
 
 :::tip
 
-- Learn how to [Override the Default ISM](./custom-ISM.mdx)
+- Learn how to [Create your own ISM](./custom-ISM.mdx)
 
 :::

--- a/docs/protocol/ISM/modular-security.mdx
+++ b/docs/protocol/ISM/modular-security.mdx
@@ -8,31 +8,6 @@ Hyperlane is secured by **Interchain Security Modules** (ISMs). ISMs are smart c
 
 <IsmDiagram />
 
-## Available ISMs
-
-### Standard ISMs
-
-Standard ISMs are pre-built modules developed by the AW team.
-
-| ISM Type            | Description                                                                    | Type     |
-| ------------------- | ------------------------------------------------------------------------------ | -------- |
-| **Multisig ISM**    | Verifies messages through validator consensus                                  | Standard |
-| **Routing ISM**     | Routes verification to different ISMs based on origin chain or message content | Standard |
-| **Aggregation ISM** | Combines multiple ISMs to require verification from several sources            | Standard |
-| **CCIP-Read ISM**   | Verifies messages using off-chain data via EIP-3668                            | Standard |
-
-### Community ISMs
-
-Community ISMs are developed and maintained by the community to extend ISM capabilities.
-
-| ISM Type              | Description                                                                                                        | Type      |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------ | --------- |
-| Wormhole ISM          | Verifies messages using attestations from Wormhole's guardian network, requiring 13 of 19 guardians for validation | Community |
-| Polygon PoS ISM       | Uses Polygon's state sync mechanism for secure message passing between Ethereum ↔ Polygon PoS                      | Community |
-| Optimistic ISM        | Implements an optimistic verification model with a fraud window where watchers can flag fraudulent messages        | Community |
-| OP Stack ISM          | Uses OP Stack rollup's settlement layer security for messages between Ethereum ↔ OP Stack rollups                  | Community |
-| Arbitrum L2 to L1 ISM | Uses Arbitrum rollup's security properties for messages sent from Arbitrum L2 ↔ Ethereum                           | Community |
-
 ## Core Concepts
 
 ### Default vs Custom ISM
@@ -46,7 +21,7 @@ Application-specific ISM can be:
 - **Customized**: Create entirely new ISMs tailored to specific needs
 
 :::info
-The "default ISM" refers to the pre-configured security module on the Mailbox contract (the Multisig ISM) that's used when applications don't specify their own custom ISM.
+The "default ISM" refers to the pre-configured security module on the Mailbox contract (that is the Multisig ISM) which is used when applications don't specify their own custom ISM.
 :::
 
 #### Configure
@@ -72,3 +47,28 @@ For example, application developers can build ISMs that adjust security models b
 Learn how to [Create your own ISM](./custom-ISM.mdx)
 
 :::
+
+## Available ISMs
+
+### Standard ISMs
+
+Standard ISMs are pre-built modules developed by the AW team.
+
+| ISM Type            | Description                                                                    | Type     |
+| ------------------- | ------------------------------------------------------------------------------ | -------- |
+| **Multisig ISM**    | Verifies messages through validator consensus                                  | Standard |
+| **Routing ISM**     | Routes verification to different ISMs based on origin chain or message content | Standard |
+| **Aggregation ISM** | Combines multiple ISMs to require verification from several sources            | Standard |
+| **CCIP-Read ISM**   | Verifies messages using off-chain data sources                                 | Standard |
+
+### Community ISMs
+
+Community ISMs are developed and maintained by the community to extend ISM capabilities.
+
+| ISM Type              | Description                                                                                                 | Type      |
+| --------------------- | ----------------------------------------------------------------------------------------------------------- | --------- |
+| Wormhole ISM          | Verifies messages using attestations from Wormhole's guardian network                                       | Community |
+| Polygon PoS ISM       | Uses Polygon's state sync mechanism for secure message passing between Ethereum ↔ Polygon PoS               | Community |
+| Optimistic ISM        | Implements an optimistic verification model with a fraud window where watchers can flag fraudulent messages | Community |
+| OP Stack ISM          | Uses OP Stack rollup's settlement layer security for messages between Ethereum ↔ OP Stack rollups           | Community |
+| Arbitrum L2 to L1 ISM | Uses Arbitrum rollup's security properties for messages sent from Arbitrum L2 ↔ Ethereum                    | Community |

--- a/docs/protocol/ISM/sequence-diagram.mdx
+++ b/docs/protocol/ISM/sequence-diagram.mdx
@@ -18,7 +18,8 @@ The Relayer is just a messenger - it doesn't verify anything itself, it only hel
 
 - If the recipient does not implement `ISpecifiesInterchainSecurityModule` or `recipient.interchainSecurityModule()` returns `address(0)`, the default ISM configured on the [Mailbox](../mailbox.mdx) will be used to verify the message.
 - This is omitted from the sequence diagram for clarity.
-  :::
+
+:::
 
 ```mermaid
 sequenceDiagram

--- a/docs/protocol/ISM/sequence-diagram.mdx
+++ b/docs/protocol/ISM/sequence-diagram.mdx
@@ -8,9 +8,7 @@ The verification process involves three key components:
 
 1. The **Mailbox contract** - The main entry point for message processing
 2. The **ISM (Interchain Security Module)** - The security verification contract
-3. The **Recipient contract** - Your application that receives the message
-
-The Relayer is just a messenger - it doesn't verify anything itself, it only helps by providing the necessary metadata for verification.
+3. The **Recipient contract** - The application that receives the message
 
 ## Sequence Diagram
 
@@ -64,7 +62,3 @@ sequenceDiagram
 
    - Upon successful verification (when `verify()` returns `true`), Mailbox calls `recipient.handle()`
    - If verification fails, the transaction reverts and the message is rejected
-
-:::note
-The "default ISM" is the pre-configured security module on the Mailbox contract (the Multisig ISM) that's used when applications don't specify their own custom ISM.
-:::

--- a/docs/protocol/ISM/sequence-diagram.mdx
+++ b/docs/protocol/ISM/sequence-diagram.mdx
@@ -1,13 +1,24 @@
-# Sequence diagram
+# Message Verification Flow
 
-The following shows a simplified sequence diagram of an interchain message being verified and delivered on the destination chain.
+When a message is sent between chains, it goes through a verification process to ensure its authenticity. This page explains how that process works.
+
+## Overview
+
+The verification process involves three key components:
+
+1. The **Mailbox contract** - The main entry point for message processing
+2. The **ISM (Interchain Security Module)** - The security verification contract
+3. The **Recipient contract** - Your application that receives the message
+
+The Relayer is just a messenger - it doesn't verify anything itself, it only helps by providing the necessary metadata for verification.
+
+## Sequence Diagram
 
 :::info
 
 - If the recipient does not implement `ISpecifiesInterchainSecurityModule` or `recipient.interchainSecurityModule()` returns `address(0)`, the default ISM configured on the [Mailbox](../mailbox.mdx) will be used to verify the message.
 - This is omitted from the sequence diagram for clarity.
-
-:::
+  :::
 
 ```mermaid
 sequenceDiagram
@@ -26,3 +37,33 @@ sequenceDiagram
     Mailbox->>Recipient: handle(origin, sender, body)
 
 ```
+
+## How It Works
+
+1. **Type Identification**
+
+   - The Relayer calls `moduleType()` on the ISM to determine its category
+   - Based on this type (e.g., `MULTISIG`, `ROUTING`, `AGGREGATION`), the Relayer knows what verification proof to collect
+   - For Multisig ISMs, this means gathering cryptographic signatures from validators
+
+2. **Message Submission**
+
+   - The Relayer calls `Mailbox.process()` providing both:
+     - The original message
+     - The collected verification metadata
+
+3. **Verification Process**
+
+   - Mailbox queries the recipient contract via `interchainSecurityModule()`
+   - If no ISM is specified, Mailbox uses the default ISM
+   - Mailbox then forwards the message and metadata to the ISM's `verify()` function
+   - The ISM executes its security logic (e.g., signature verification, threshold checking)
+
+4. **Message Delivery**
+
+   - Upon successful verification (when `verify()` returns `true`), Mailbox calls `recipient.handle()`
+   - If verification fails, the transaction reverts and the message is rejected
+
+:::note
+The "default ISM" is the pre-configured security module on the Mailbox contract (the Multisig ISM) that's used when applications don't specify their own custom ISM.
+:::

--- a/docs/protocol/ISM/third-party-ISMs/OPStack-ISM.mdx
+++ b/docs/protocol/ISM/third-party-ISMs/OPStack-ISM.mdx
@@ -1,3 +1,0 @@
-# OP Stack ISM
-
-The OP Stack ISM is used along with the OP Stack hook to leverage the security of an OP Stack rollup's [settlement layer](https://stack.optimism.io/docs/understand/landscape/#execution) for messages passed between Ethereum and the rollup. See the [OP Stack Hook](/docs/reference/hooks/op-stack.mdx) for more information.

--- a/docs/protocol/ISM/third-party-ISMs/arbitrum-L2-to-L1-ISM.mdx
+++ b/docs/protocol/ISM/third-party-ISMs/arbitrum-L2-to-L1-ISM.mdx
@@ -1,3 +1,0 @@
-# Arbitrum L2 to L1 ISM
-
-The Arbitrum L2 to L1 ISM is used along with the Arbitrum L2 to L1 hook to leverage the security of the Arbitrum rollup for messages passed from the Arbitrum L2 to Ethereum. See the [Arbitrum L2 to L1 Hook](/docs/reference/hooks/arbitrum-L2-to-L1.mdx) for more information.

--- a/docs/protocol/ISM/third-party-ISMs/community-ISMs.mdx
+++ b/docs/protocol/ISM/third-party-ISMs/community-ISMs.mdx
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Community ISMs are developed and maintained by the community. These ISMs extend Hyperlane's security capabilities with specialized verification logic, alternative trust models, or integration with external security infrastructure. By using community ISMs, developers can implement custom security requirements while still benefiting from Hyperlane's messaging infrastructure.
+Community ISMs are developed and maintained by the community. These ISMs extend Hyperlane's security capabilities with specialized verification logic, alternative trust models, or integration with external infrastructure. By using community ISMs, developers can implement custom security requirements while still benefiting from Hyperlane's messaging infrastructure.
 
 When using a community ISM, developers should review the implementation and security properties to ensure they match their application's requirements.
 

--- a/docs/protocol/ISM/third-party-ISMs/polygon-POS-ISM.mdx
+++ b/docs/protocol/ISM/third-party-ISMs/polygon-POS-ISM.mdx
@@ -1,3 +1,0 @@
-# Polygon PoS ISM
-
-The Polygon PoS ISM is used along with the Polygon PoS hook to leverage the security of the Polygon [state sync mechanism](https://docs.polygon.technology/pos/architecture/bor/state-sync/) for messages passed between Ethereum and Polygon PoS chain. See the [Polygon PoS Hook](/docs/reference/hooks/polygon-pos.mdx) for more information.

--- a/docs/protocol/ISM/third-party-ISMs/wormhole-ISM.mdx
+++ b/docs/protocol/ISM/third-party-ISMs/wormhole-ISM.mdx
@@ -1,22 +1,4 @@
-# Community ISMs
-
-## Overview
-
-Community ISMs are developed and maintained by the community. These ISMs extend Hyperlane's security capabilities with specialized verification logic, alternative trust models, or integration with external security infrastructure. By using community ISMs, developers can implement custom security requirements while still benefiting from Hyperlane's messaging infrastructure.
-
-When using a community ISM, developers should review the implementation and security properties to ensure they match their application's requirements.
-
-## Available Community ISMs
-
-| Name                  | Description                                                                                                        | Type      |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------ | --------- |
-| Wormhole ISM          | Verifies messages using attestations from Wormhole's guardian network, requiring 13 of 19 guardians for validation | Community |
-| Polygon PoS ISM       | Uses Polygon's state sync mechanism for secure message passing between Ethereum ↔ Polygon PoS                      | Community |
-| Optimistic ISM        | Implements an optimistic verification model with a fraud window where watchers can flag fraudulent messages        | Community |
-| OP Stack ISM          | Uses OP Stack rollup's settlement layer security for messages between Ethereum ↔ OP Stack rollups                  | Community |
-| Arbitrum L2 to L1 ISM | Uses Arbitrum rollup's security properties for messages sent from Arbitrum L2 ↔ Ethereum                           | Community |
-
-## Wormhole ISM
+# Wormhole ISM
 
 :::warning
 `WormholeISM` is coming soon and is not yet implemented. This page is shown for informational purposes only. Details may change as the design matures.
@@ -27,29 +9,3 @@ The `WormholeISM` encodes the security model used by [Wormhole's](https://wormho
 This ISM requires that 13 of the 19 [Wormhole guardians](https://wormhole.com/network/#guardians) attest to the validity of a Hyperlane message.
 
 Developers can compose a Wormhole ISM with a [Multisig ISM](../multisig-ISM.mdx) using an [Aggregation ISM](../aggregation-ISM.mdx) to require that m of n Hyperlane validators **and** 13-of-19 Wormhole guardians verify a message.
-
-## Polygon PoS ISM
-
-The Polygon PoS ISM is used along with the Polygon PoS hook to leverage the security of the Polygon [state sync mechanism](https://docs.polygon.technology/pos/architecture/bor/state-sync/) for messages passed between Ethereum and Polygon PoS chain. See the [Polygon PoS Hook](/docs/reference/hooks/polygon-pos.mdx) for more information.
-
-## Optimistic ISM
-
-Prioritizing safety over liveness
-
-:::warning
-`OptimisticISM` is coming soon and is not yet implemented. This page is shown for informational purposes only. Details may change as the design matures.
-:::
-
-The `OptimisticISM` encodes the optimistic verification security model pioneered by [Optics](https://docs.celo.org/protocol/bridge/optics) and adopted by [Synapse](https://docs.synapseprotocol.com/docs/RFQ/Security/#proofs), [Nomad](https://docs.nomad.xyz/the-nomad-protocol/verification-mechanisms/optimistic-verification), and [Connext](https://blog.connext.network/optimistic-bridges-fb800dc7b0e0).
-
-`OptimisticISMs` rely on a fraud window after message verification, during which `m` of `n` **watchers** configured on the `OptimisticISM` have an opportunity to flag messages as fraudulent, preventing them from being delivered to their recipient.
-
-**This security model prioritizes safety over liveness;** the increased message latency allows for the addition of a second layer of security, the watchers, without significant increases in gas costs.
-
-## OP Stack ISM
-
-The OP Stack ISM is used along with the OP Stack hook to leverage the security of an OP Stack rollup's [settlement layer](https://stack.optimism.io/docs/understand/landscape/#execution) for messages passed between Ethereum and the rollup. See the [OP Stack Hook](/docs/reference/hooks/op-stack.mdx) for more information.
-
-## Arbitrum L2 to L1 ISM
-
-The Arbitrum L2 to L1 ISM is used along with the Arbitrum L2 to L1 hook to leverage the security of the Arbitrum rollup for messages passed from the Arbitrum L2 to Ethereum. See the [Arbitrum L2 to L1 Hook](/docs/reference/hooks/arbitrum-L2-to-L1.mdx) for more information.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -189,7 +189,7 @@ const config = {
             ],
           },
           {
-            to: "/docs/protocol/ISM/third-party-ISMs/optimistic-ISM",
+            to: "/docs/protocol/ISM/third-party-ISMs/community-ISMs",
             from: ["/docs/protocol/sovereign-consensus/optimistic-ism"],
           },
           {
@@ -263,7 +263,7 @@ const config = {
             from: ["/docs/protocol/sovereign-consensus/routing-ism"],
           },
           {
-            to: "/docs/protocol/ISM/third-party-ISMs/wormhole-ISM",
+            to: "/docs/protocol/ISM/third-party-ISMs/community-ISMs",
             from: ["/docs/protocol/sovereign-consensus/wormhole-ism"],
           },
           {

--- a/sidebars.js
+++ b/sidebars.js
@@ -33,6 +33,11 @@ const sidebars = {
           id: "guides/deploy-warp-route",
           label: "Bridge a Token",
         },
+        {
+          type: "doc",
+          id: "guides/local-testnet-setup",
+          label: "Local Setup: Sending Messages between Anvil Nodes",
+        },
       ],
     },
     {
@@ -98,11 +103,6 @@ const sidebars = {
               label: "Deploy Hyperlane with Local Agents",
             },
           ],
-        },
-        {
-          type: "doc",
-          id: "guides/local-testnet-setup",
-          label: "Local Setup: Sending Messages between Anvil Nodes",
         },
         {
           type: "category",
@@ -438,7 +438,7 @@ const sidebars = {
             {
               type: "doc",
               id: "protocol/ISM/custom-ISM",
-              label: "Override the Default ISM",
+              label: "Create your own ISM",
             },
             {
               type: "category",
@@ -479,37 +479,9 @@ const sidebars = {
               ],
             },
             {
-              type: "category",
+              type: "doc",
+              id: "protocol/ISM/third-party-ISMs/community-ISMs",
               label: "Community ISMs",
-              collapsible: true,
-              collapsed: true,
-              items: [
-                {
-                  type: "doc",
-                  id: "protocol/ISM/third-party-ISMs/wormhole-ISM",
-                  label: "Wormhole ISM",
-                },
-                {
-                  type: "doc",
-                  id: "protocol/ISM/third-party-ISMs/optimistic-ISM",
-                  label: "Optimistic ISM",
-                },
-                {
-                  type: "doc",
-                  id: "protocol/ISM/third-party-ISMs/OPStack-ISM",
-                  label: "OP Stack ISM",
-                },
-                {
-                  type: "doc",
-                  id: "protocol/ISM/third-party-ISMs/polygon-POS-ISM",
-                  label: "Polygon PoS ISM",
-                },
-                {
-                  type: "doc",
-                  id: "protocol/ISM/third-party-ISMs/arbitrum-L2-to-L1-ISM",
-                  label: "Arbitrum L2 to L1 ISM",
-                },
-              ],
             },
             {
               type: "category",


### PR DESCRIPTION
- [x] Change the guide name from 'override default ism' to 'create your own ism'
- [x] Add more details to the sequence diagram page to explain the steps clearly 
- [x] Consolidate the community isms into a single page 
- [x] Remove the single ISM pages for the community ISMS
- [x] Create an ISMs table for the ism intro page 
- [x] Make it clear that the default ISM is not an ISM itself